### PR TITLE
Add reviewer revision reproducibility support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Abstract
 
-AI-text detectors face a critical robustness challenge: adversarial paraphrasing attacks that preserve semantics while evading detection. We introduce StealthRL, a reinforcement learning framework that stress-tests detector robustness under realistic adversarial conditions. StealthRL trains a paraphrase policy against a multi-detector ensemble using Group Relative Policy Optimization (GRPO) with LoRA adapters on Qwen3-4B, optimizing a composite reward that balances detector evasion with semantic preservation. We evaluate six attack settings (M0-M5) on the full filtered MAGE test pool (15,310 human / 14,656 AI) against four detectors: RoBERTa, Fast-DetectGPT, Binoculars, and MAGE. StealthRL achieves near-zero detection on three of the four detectors and a 0.024 mean TPR@1%FPR, reducing mean AUROC from 0.79 to 0.43 and attaining a 97.6% attack success rate. Critically, attacks transfer to two held-out detectors not seen during training, revealing shared architectural vulnerabilities rather than detector-specific brittleness. We additionally conduct LLM-based quality evaluation via Likert scoring on 500 matched samples per method, analyze detector score distributions to explain why evasion succeeds, and provide per-detector AUROC with bootstrap confidence intervals. Our results expose significant robustness gaps in current AI-text detection and establish StealthRL as a principled adversarial evaluation protocol.
+AI-text detectors are increasingly used in high-stakes settings, yet their robustness to meaning-preserving adversarial rewriting remains uncertain. We introduce StealthRL, a reinforcement learning framework for stress-testing AI-text detectors with adaptive paraphrase attacks. StealthRL trains a paraphrase policy against a detector ensemble while preserving semantic content, then evaluates transfer to held-out detector families. On the full filtered MAGE test pool (15,310 human / 14,656 AI), StealthRL reduces mean AUROC from 0.79 to 0.43 and achieves a 0.024 mean TPR@1%FPR across RoBERTa, Fast-DetectGPT, Binoculars, and MAGE. The attack transfers to two detectors not used during training, exposing shared vulnerabilities rather than a single-detector failure. We further analyze detector score distributions and evaluate quality with E5, BERTScore, and LLM-based Likert ratings. Our results show that current AI-text detectors remain brittle under realistic paraphrasing pressure and provide a reproducible protocol for adversarial robustness evaluation.
 
 ## What This Repository Contains
 
@@ -152,6 +152,18 @@ python scripts/run_gpt_quality_only.py \
   --env-file ~/.config/stealthrl/eval.env
 ```
 
+6. If you only need to add BERTScore to an assembled run with cached outputs:
+
+```bash
+python scripts/compute_bertscore_for_run.py \
+  --run-dir outputs/eval_runs/full_mage_repro/assembled \
+  --device cuda:0 \
+  --batch-size 16 \
+  --chunk-size 512
+```
+
+The BERTScore script updates `quality.parquet` and `quality.csv` in place after every chunk, so interrupted runs can be resumed without recomputing completed rows. Use `--limit-per-method` for a small smoke test and `--force` only when intentionally recomputing existing BERTScore columns.
+
 ### Main output artifacts
 
 The staged run produces:
@@ -163,6 +175,10 @@ The staged run produces:
 - `assembled/quality.parquet`: automatic quality metrics
 - `assembled/quality_gpt.parquet`: GPT/Likert quality ratings
 - `assembled/figures/`: paper-ready plots
+
+### Canonical paper settings
+
+The primary paper checkpoint uses `configs/tinker_mage_10k.yaml` as the canonical training configuration: Qwen3-4B-Instruct with LoRA rank 32, GRPO group size 8, 10,000 MAGE training samples, three epochs, learning rate `2.8e-4`, KL coefficient `0.05`, temperature `1.0`, top-p `0.9`, and a two-detector reward ensemble weighted `0.6` RoBERTa / `0.4` Fast-DetectGPT. Other configs in `configs/` are retained as legacy examples, smoke-test settings, or ablation templates and should not be treated as paper-authoritative unless explicitly documented.
 
 ## Training Implementation
 
@@ -243,6 +259,7 @@ The public evaluation code computes:
 - TPR@5%FPR
 - ASR
 - E5 similarity
+- BERTScore precision/recall/F1
 - perplexity
 - edit rate
 - GPT/Likert quality and similarity scores

--- a/configs/tinker_mage_10k.yaml
+++ b/configs/tinker_mage_10k.yaml
@@ -1,5 +1,5 @@
-# StealthRL Training Configuration - 10K MAGE samples with filtering
-# Optimized for fast iteration with production-quality hyperparameters
+# StealthRL Training Configuration - canonical paper checkpoint
+# 10K filtered MAGE training samples with the hyperparameters reported in the paper.
 
 # Model settings
 model:
@@ -16,9 +16,9 @@ lora:
 # Training hyperparameters
 training:
   learning_rate: 2.8e-4  # Optimized for rank 32
-  batch_size: 64  # Match your old successful run
+  batch_size: 16  # Paper setting
   group_size: 8  # Better than 4 for GRPO advantage estimation
-  num_epochs: 5  # Keep your original setting
+  num_epochs: 3  # Paper setting
   num_substeps: 1
   max_tokens: 512
 
@@ -27,7 +27,7 @@ sampling:
   temperature: 1.0
   temperature_schedule: "constant"
   temperature_decay: 0.95
-  top_p: 0.95
+  top_p: 0.9
   batched_sampling: true
 
 # GRPO settings
@@ -37,9 +37,9 @@ grpo:
   reward_clip: null
   remove_constant_reward_groups: true
 
-# KL divergence penalty - FIXED (was 0.05 in your old run, too high)
+# KL divergence penalty
 kl:
-  penalty_coef: 0.01  # Reduced from 0.05 for better exploration
+  penalty_coef: 0.05
   target: null
   adapt_rate: 0.1
 
@@ -58,9 +58,9 @@ curriculum:
 # Reward function configuration - Multi-objective RL formulation
 reward:
   # Multi-objective weights: R = α·R_det + β·R_sem
-  # Both components use full [0,1] range for balanced optimization
+  # Detector evasion is the dominant signal; E5 is a soft fidelity regularizer.
   detector_weight: 1.0      # α: detector evasion (1 - P(AI))
-  semantic_weight: 1.0      # β: semantic similarity (E5 cosine)
+  semantic_weight: 0.1      # β: semantic similarity (E5 cosine)
   perplexity_weight: 0.0    # Disabled - rely on KL penalty for fluency
   
   # Component toggles

--- a/eval/plots.py
+++ b/eval/plots.py
@@ -40,14 +40,14 @@ def _apply_paper_style():
         rc={
             "figure.dpi": 150,
             "savefig.dpi": 300,
-            "axes.titlesize": 12,
+            "axes.titlesize": 14,
             "axes.titlepad": 8,
-            "axes.labelsize": 11,
+            "axes.labelsize": 12,
             "axes.labelpad": 6,
-            "xtick.labelsize": 9,
-            "ytick.labelsize": 9,
-            "legend.fontsize": 9,
-            "legend.title_fontsize": 9,
+            "xtick.labelsize": 10,
+            "ytick.labelsize": 10,
+            "legend.fontsize": 10,
+            "legend.title_fontsize": 10,
             "axes.linewidth": 0.8,
             "grid.linewidth": 0.6,
             "grid.alpha": 0.25,
@@ -214,11 +214,14 @@ def create_heatmap(
         vmax=vmax,
         ax=ax,
         cbar_kws={"label": value_col},
+        annot_kws={"fontsize": 11},
     )
     
-    ax.set_title(title, fontsize=14, fontweight='bold')
+    ax.set_title(title, fontsize=15, fontweight='bold')
     ax.set_xlabel("Method", fontsize=12)
     ax.set_ylabel("Detector", fontsize=12)
+    ax.tick_params(axis="x", labelsize=10)
+    ax.tick_params(axis="y", labelsize=10)
     
     plt.tight_layout()
     
@@ -775,9 +778,9 @@ def create_method_comparison_summary(
         [_pretty_detector_name(d).replace(' ', '\n') for d in detectors],
         rotation=45,
         ha='right',
-        fontsize=8,
+        fontsize=10,
     )
-    ax1.legend(fontsize=8, ncol=2)
+    ax1.legend(fontsize=10, ncol=2)
     ax1.set_ylim(0, 1.05)
     
     # Panel 2: Mean AUROC with error bars
@@ -795,14 +798,14 @@ def create_method_comparison_summary(
     ax2.set_xticks(x2)
     ax2.set_xticklabels(
         [METHOD_NAMES.get(m, m).replace(' ', '\n') for m in mean_aurocs[method_col]],
-        fontsize=9,
+        fontsize=10,
     )
     ax2.set_ylim(0, 1.05)
     
     # Add value labels
     for bar, val in zip(bars, mean_aurocs['mean']):
         ax2.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 0.02,
-                 f'{val:.2f}', ha='center', fontsize=9, fontweight='bold')
+                 f'{val:.2f}', ha='center', fontsize=10, fontweight='bold')
     
     # Panel 3: TPR@1%FPR grouped bars
     ax3 = axes[1, 0]
@@ -823,7 +826,7 @@ def create_method_comparison_summary(
         [_pretty_detector_name(d).replace(' ', '\n') for d in detectors],
         rotation=45,
         ha='right',
-        fontsize=8,
+        fontsize=10,
     )
     ax3.set_ylim(0, 1.05)
     
@@ -842,20 +845,20 @@ def create_method_comparison_summary(
         ax4.set_xticks(x4)
         ax4.set_xticklabels(
             [METHOD_NAMES.get(m, m).replace(' ', '\n') for m in mean_asr[method_col]],
-            fontsize=9,
+            fontsize=10,
         )
         ax4.set_ylim(0, 1.05)
         
         # Add value labels
         for bar, val in zip(bars, mean_asr['asr']):
             ax4.text(bar.get_x() + bar.get_width()/2, bar.get_height() + 0.02,
-                     f'{val:.1%}', ha='center', fontsize=9, fontweight='bold')
+                     f'{val:.1%}', ha='center', fontsize=10, fontweight='bold')
     else:
         ax4.text(0.5, 0.5, 'ASR data not available', ha='center', va='center',
                  transform=ax4.transAxes, fontsize=12)
         ax4.set_title('(d) Attack Success Rate', fontweight='bold')
     
-    fig.suptitle('Detection Evasion Results Summary', fontsize=16, fontweight='bold', y=1.02)
+    fig.suptitle('Detection Evasion Results Summary', fontsize=17, fontweight='bold', y=1.02)
     plt.tight_layout()
     
     if output_path:
@@ -1685,6 +1688,14 @@ def create_quality_table(
         'edit_rate': 'mean',
         'valid': 'mean',
     }
+    if 'bertscore_f1' in df.columns:
+        agg_cols = {
+            'sim_e5': 'mean',
+            'bertscore_f1': 'mean',
+            'ppl_score': 'mean',
+            'edit_rate': 'mean',
+            'valid': 'mean',
+        }
     if 'quality_rating' in df.columns:
         agg_cols['quality_rating'] = 'mean'
     if 'similarity_rating' in df.columns:
@@ -1707,6 +1718,7 @@ def create_quality_table(
         columns={
             "method": "Method",
             "sim_e5": "E5 Sim.",
+            "bertscore_f1": "BERTScore",
             "ppl_score": "PPL",
             "edit_rate": "Edit Rate",
             "valid": "Valid",
@@ -1723,7 +1735,7 @@ def create_quality_table(
     if format == "markdown":
         table = summary.to_markdown(index=False)
     elif format == "latex":
-        table = summary.to_latex(index=False, escape=False, column_format="lrrrrrr")
+        table = summary.to_latex(index=False, escape=False, column_format="l" + "r" * (len(summary.columns) - 1))
     else:
         table = summary.to_string(index=False)
     

--- a/scripts/compute_bertscore_for_run.py
+++ b/scripts/compute_bertscore_for_run.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""
+Compute BERTScore for an assembled StealthRL evaluation run.
+
+The script reuses an existing run directory containing dataset_samples.json,
+raw_outputs.json, and quality.parquet. It updates quality.parquet/csv in place
+with bertscore_precision, bertscore_recall, and bertscore_f1 columns, saving
+after each chunk so long runs can be resumed safely.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+import pandas as pd
+
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+from eval.data import load_eval_dataset_with_ids
+from eval.plots import create_quality_table
+
+
+LOGGER = logging.getLogger("compute_bertscore_for_run")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compute BERTScore for an assembled eval run")
+    parser.add_argument("--run-dir", required=True, help="Assembled run directory")
+    parser.add_argument("--methods", nargs="+", default=["m0", "m1", "m2", "m3", "m4", "m5"])
+    parser.add_argument("--model-type", default="roberta-large")
+    parser.add_argument("--lang", default="en")
+    parser.add_argument("--device", default=None, help="Example: cuda:2 or cpu")
+    parser.add_argument("--batch-size", type=int, default=16)
+    parser.add_argument("--chunk-size", type=int, default=512)
+    parser.add_argument("--limit-per-method", type=int, default=None, help="Smoke-test cap")
+    parser.add_argument("--cache-dir", default="cache")
+    parser.add_argument("--rescale-with-baseline", action="store_true")
+    parser.add_argument("--force", action="store_true", help="Recompute rows with existing BERTScore")
+    parser.add_argument("--log-level", default="INFO")
+    return parser.parse_args()
+
+
+def _chunks(values: List[int], size: int) -> Iterable[List[int]]:
+    for start in range(0, len(values), size):
+        yield values[start : start + size]
+
+
+def _load_original_texts(run_dir: Path, cache_dir: str) -> Dict[str, Dict[str, str]]:
+    ids = json.loads((run_dir / "dataset_samples.json").read_text())
+    originals: Dict[str, Dict[str, str]] = {}
+
+    for dataset_name, split_ids in ids.items():
+        dataset = load_eval_dataset_with_ids(
+            name=dataset_name,
+            human_ids=split_ids["human_ids"],
+            ai_ids=split_ids["ai_ids"],
+            cache_dir=cache_dir,
+        )
+        originals[dataset_name] = {sample.id: sample.text for sample in dataset.ai_samples}
+
+    return originals
+
+
+def _load_paraphrases(run_dir: Path) -> Dict[str, Dict[str, Dict[str, str]]]:
+    ids = json.loads((run_dir / "dataset_samples.json").read_text())
+    raw_outputs = json.loads((run_dir / "raw_outputs.json").read_text())
+    paraphrases: Dict[str, Dict[str, Dict[str, str]]] = {}
+
+    for dataset_name, split_ids in ids.items():
+        ai_ids = split_ids["ai_ids"]
+        paraphrases[dataset_name] = {}
+        for method, outputs in raw_outputs[dataset_name].items():
+            if len(outputs) != len(ai_ids):
+                raise ValueError(
+                    f"Length mismatch for {dataset_name}/{method}: {len(outputs)} vs {len(ai_ids)}"
+                )
+            paraphrases[dataset_name][method] = dict(zip(ai_ids, outputs))
+
+    return paraphrases
+
+
+def main() -> int:
+    args = parse_args()
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s | %(levelname)s | %(message)s",
+    )
+
+    run_dir = Path(args.run_dir)
+    quality_path = run_dir / "quality.parquet"
+    if not quality_path.exists():
+        raise FileNotFoundError(f"Missing {quality_path}")
+
+    quality_df = pd.read_parquet(quality_path)
+    for col in ("bertscore_precision", "bertscore_recall", "bertscore_f1"):
+        if col not in quality_df.columns:
+            quality_df[col] = pd.NA
+
+    originals = _load_original_texts(run_dir, args.cache_dir)
+    paraphrases = _load_paraphrases(run_dir)
+
+    from bert_score import BERTScorer
+
+    LOGGER.info(
+        "Loading BERTScorer(model_type=%s, lang=%s, device=%s)",
+        args.model_type,
+        args.lang,
+        args.device or "auto",
+    )
+    scorer = BERTScorer(
+        model_type=args.model_type,
+        lang=args.lang,
+        device=args.device,
+        rescale_with_baseline=args.rescale_with_baseline,
+    )
+
+    target_mask = quality_df["method"].isin(args.methods)
+    if not args.force:
+        target_mask &= quality_df["bertscore_f1"].isna()
+
+    pending_indices = quality_df[target_mask].index.tolist()
+    if args.limit_per_method is not None:
+        capped = []
+        for method in args.methods:
+            method_indices = quality_df[target_mask & (quality_df["method"] == method)].index.tolist()
+            capped.extend(method_indices[: args.limit_per_method])
+        pending_indices = capped
+
+    LOGGER.info("Rows pending BERTScore: %d", len(pending_indices))
+    if not pending_indices:
+        return 0
+
+    for chunk_no, chunk_indices in enumerate(_chunks(pending_indices, args.chunk_size), start=1):
+        refs: List[str] = []
+        cands: List[str] = []
+        for idx in chunk_indices:
+            row = quality_df.loc[idx]
+            dataset_name = row["dataset"]
+            method = row["method"]
+            sample_id = row["sample_id"]
+            refs.append(originals[dataset_name][sample_id])
+            cands.append(paraphrases[dataset_name][method][sample_id])
+
+        precision, recall, f1 = scorer.score(cands, refs, batch_size=args.batch_size)
+        quality_df.loc[chunk_indices, "bertscore_precision"] = precision.cpu().numpy().tolist()
+        quality_df.loc[chunk_indices, "bertscore_recall"] = recall.cpu().numpy().tolist()
+        quality_df.loc[chunk_indices, "bertscore_f1"] = f1.cpu().numpy().tolist()
+
+        quality_df.to_parquet(quality_path)
+        quality_df.to_csv(run_dir / "quality.csv", index=False)
+        LOGGER.info("Saved chunk %d (%d rows)", chunk_no, len(chunk_indices))
+
+    tables_dir = run_dir / "tables"
+    tables_dir.mkdir(parents=True, exist_ok=True)
+    create_quality_table(
+        quality_df.to_dict("records"),
+        output_path=str(tables_dir / "table_quality.md"),
+        format="markdown",
+    )
+    create_quality_table(
+        quality_df.to_dict("records"),
+        output_path=str(tables_dir / "table_quality.tex"),
+        format="latex",
+    )
+
+    summary = quality_df.groupby("method")["bertscore_f1"].mean().round(4)
+    LOGGER.info("BERTScore F1 means:\n%s", summary.to_string())
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add a resumable BERTScore utility for assembled evaluation runs.
- Update plot/table generation so quality tables can report BERTScore when present while remaining compatible with older artifacts.
- Align the public README and canonical paper config with the revised paper settings and reproduction flow.

## Validation

- `python -m py_compile scripts/compute_bertscore_for_run.py eval/plots.py`
- `python scripts/compute_bertscore_for_run.py --help`