### PR TITLE
[codex] Add StealthRL demo website and Azure GPU backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.venv
+.venv-demo
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+.mypy_cache
+.ruff_cache
+.DS_Store
+arxiv
+acl2026
+outputs
+data
+*.sqlite3
+*.db
+demo/.env

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ runs/
 # Environment
 .env
 .env.local
+.venv-azure/
+.azure-tools/
 
 # Testing
 .pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,4 @@ report/
 *.gguf
 *.sqlite3
 demo/data/
+deploy/azure/static_dist/

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,7 @@ runs/
 *.jsonl
 *.json
 *.html
+!demo/static/*.html
 
 # Model files
 *.pt
@@ -98,3 +99,5 @@ AGENT.md
 cache/
 report/
 *.gguf
+*.sqlite3
+demo/data/

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ runs/
 .env.local
 .venv-azure/
 .azure-tools/
+.cloudflare-tools/
 
 # Testing
 .pytest_cache/
@@ -104,3 +105,4 @@ report/
 *.sqlite3
 demo/data/
 deploy/azure/static_dist/
+deploy/cloudflare/static_dist/

--- a/README.md
+++ b/README.md
@@ -108,6 +108,17 @@ python scripts/run_full_mage_research_eval.py \
   --gpus 0 1 2 3
 ```
 
+### Run the demo website
+
+The repository includes a FastAPI-backed demo website under `demo/`. It serves a polished static UI and exposes `POST /api/paraphrase` with API-key support plus a 20/day public quota for unauthenticated users.
+
+```bash
+pip install -r demo/requirements.txt
+uvicorn demo.stealthrl_demo.app:app --reload --port 8080
+```
+
+By default the demo runs in zero-cost `mock` mode for UI testing. To use the real StealthRL sampler, set `STEALTHRL_DEMO_INFERENCE_BACKEND=tinker`, `STEALTHRL_DEMO_CHECKPOINT_JSON`, and `TINKER_API_KEY`. See `demo/README.md` for API-key, quota, Docker, and AWS deployment notes.
+
 ## Reproducing the Paper Results
 
 The paper reports results on the full filtered MAGE evaluation pool:

--- a/demo/.env.example
+++ b/demo/.env.example
@@ -1,0 +1,23 @@
+# Server
+STEALTHRL_DEMO_HOST=0.0.0.0
+STEALTHRL_DEMO_PORT=8080
+STEALTHRL_DEMO_PUBLIC_DAILY_LIMIT=20
+STEALTHRL_DEMO_PUBLIC_QUOTA_SCOPE=ip
+STEALTHRL_DEMO_DB_PATH=demo/demo_usage.sqlite3
+
+# API keys. Accepts comma-separated keys or a JSON object.
+# Examples:
+# STEALTHRL_DEMO_API_KEYS=stealth-demo-local-1,stealth-demo-local-2
+# STEALTHRL_DEMO_API_KEYS={"stealth-demo-lab":{"label":"lab","daily_limit":500}}
+STEALTHRL_DEMO_API_KEYS=
+
+# Inference backend.
+# mock: zero-cost deterministic rewrite for local/UI testing.
+# tinker: uses eval.methods.stealthrl.StealthRLTinker with the checkpoint below.
+STEALTHRL_DEMO_INFERENCE_BACKEND=mock
+STEALTHRL_DEMO_CHECKPOINT_JSON=
+TINKER_API_KEY=
+
+# Optional UI/runtime limits
+STEALTHRL_DEMO_MAX_CHARS=5000
+STEALTHRL_DEMO_REQUEST_TIMEOUT_S=90

--- a/demo/.env.example
+++ b/demo/.env.example
@@ -30,3 +30,7 @@ TINKER_API_KEY=
 # Optional UI/runtime limits
 STEALTHRL_DEMO_MAX_CHARS=5000
 STEALTHRL_DEMO_REQUEST_TIMEOUT_S=240
+
+# Comma-separated browser origins allowed to call the API when static UI is hosted separately.
+# Example: STEALTHRL_DEMO_CORS_ORIGINS=https://example.com,https://demo.example.com
+STEALTHRL_DEMO_CORS_ORIGINS=

--- a/demo/.env.example
+++ b/demo/.env.example
@@ -13,11 +13,20 @@ STEALTHRL_DEMO_API_KEYS=
 
 # Inference backend.
 # mock: zero-cost deterministic rewrite for local/UI testing.
+# hf: loads the released Hugging Face PEFT adapter locally; requires enough GPU memory for Qwen3-4B.
 # tinker: uses eval.methods.stealthrl.StealthRLTinker with the checkpoint below.
 STEALTHRL_DEMO_INFERENCE_BACKEND=mock
+
+# Hugging Face backend settings. Set CUDA_VISIBLE_DEVICES outside this file if needed.
+STEALTHRL_DEMO_HF_BASE_MODEL=Qwen/Qwen3-4B-Instruct-2507
+STEALTHRL_DEMO_HF_ADAPTER_MODEL=suraj-ranganath/StealthRL
+STEALTHRL_DEMO_HF_DTYPE=bfloat16
+STEALTHRL_DEMO_HF_DEVICE_MAP=auto
+
+# Tinker backend settings. Requires an accessible Tinker sampler checkpoint.
 STEALTHRL_DEMO_CHECKPOINT_JSON=
 TINKER_API_KEY=
 
 # Optional UI/runtime limits
 STEALTHRL_DEMO_MAX_CHARS=5000
-STEALTHRL_DEMO_REQUEST_TIMEOUT_S=90
+STEALTHRL_DEMO_REQUEST_TIMEOUT_S=240

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app
+
+WORKDIR /app
+
+COPY demo/requirements.txt /app/demo/requirements.txt
+RUN pip install --no-cache-dir -r /app/demo/requirements.txt
+
+COPY demo /app/demo
+
+EXPOSE 8080
+
+CMD ["sh", "-c", "exec uvicorn demo.stealthrl_demo.app:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/demo/Dockerfile.azure-gpu
+++ b/demo/Dockerfile.azure-gpu
@@ -1,0 +1,38 @@
+FROM pytorch/pytorch:2.7.1-cuda12.6-cudnn9-runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app \
+    HF_HOME=/opt/stealthrl/hf-cache \
+    HF_HUB_ENABLE_HF_TRANSFER=1 \
+    STEALTHRL_DEMO_INFERENCE_BACKEND=hf \
+    STEALTHRL_DEMO_HF_BASE_MODEL=/opt/stealthrl/models/qwen3-4b-instruct-2507 \
+    STEALTHRL_DEMO_HF_ADAPTER_MODEL=/opt/stealthrl/models/stealthrl-adapter \
+    STEALTHRL_DEMO_HF_DTYPE=float16 \
+    STEALTHRL_DEMO_HF_DEVICE_MAP=auto \
+    STEALTHRL_DEMO_REQUEST_TIMEOUT_S=240
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git curl ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY demo/requirements.txt /app/demo/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r /app/demo/requirements.txt \
+    && pip install --no-cache-dir \
+        "transformers>=4.56.0" \
+        "accelerate>=1.1.0" \
+        "safetensors>=0.4.5" \
+        "huggingface_hub[hf_transfer]>=0.25.0"
+
+# Bake the model into the image so scale-to-zero cold starts do not redownload
+# multi-GB weights from Hugging Face.
+RUN python -c "from huggingface_hub import snapshot_download; snapshot_download('Qwen/Qwen3-4B-Instruct-2507', local_dir='/opt/stealthrl/models/qwen3-4b-instruct-2507'); snapshot_download('suraj-ranganath/StealthRL', local_dir='/opt/stealthrl/models/stealthrl-adapter')"
+
+COPY demo /app/demo
+
+EXPOSE 8080
+
+CMD ["sh", "-c", "exec uvicorn demo.stealthrl_demo.app:app --host 0.0.0.0 --port ${PORT:-8080}"]

--- a/demo/README.md
+++ b/demo/README.md
@@ -5,7 +5,8 @@ This is a lightweight FastAPI demo for StealthRL. It serves a static single-page
 The demo is designed to be cheap by default:
 
 - `mock` backend is zero-cost and deterministic for UI/local testing.
-- `tinker` backend lazily calls the released StealthRL sampler through Tinker when configured.
+- `hf` backend lazily loads the released Hugging Face PEFT adapter for real local inference.
+- `tinker` backend lazily calls a StealthRL sampler through Tinker when configured.
 - unauthenticated users are limited to 20 public responses per day by default.
 - API-key users can bypass the public quota or receive their own daily quota.
 
@@ -46,7 +47,20 @@ The quota database stores only daily counters keyed by hashed identifiers; it do
 
 ## Use Real StealthRL Inference
 
-The default `mock` backend is intentionally cost-free. To call the actual StealthRL sampler:
+The default `mock` backend is intentionally cost-free. To run the released Hugging Face adapter locally:
+
+```bash
+export CUDA_VISIBLE_DEVICES=4
+export STEALTHRL_DEMO_INFERENCE_BACKEND=hf
+export STEALTHRL_DEMO_HF_BASE_MODEL=Qwen/Qwen3-4B-Instruct-2507
+export STEALTHRL_DEMO_HF_ADAPTER_MODEL=suraj-ranganath/StealthRL
+export STEALTHRL_DEMO_REQUEST_TIMEOUT_S=240
+uvicorn demo.stealthrl_demo.app:app --host 0.0.0.0 --port 8080
+```
+
+The Hugging Face backend uses the released PEFT adapter and chunks multi-sentence inputs before generation so the demo preserves paragraph coverage instead of summarizing to a single sentence.
+
+To call a Tinker-hosted sampler instead:
 
 ```bash
 export STEALTHRL_DEMO_INFERENCE_BACKEND=tinker
@@ -66,14 +80,15 @@ docker run --rm -p 8080:8080 --env-file demo/.env stealthrl-demo
 
 ## AWS Deployment Notes
 
-For a judicious first deployment, use a small CPU container service and Tinker-backed inference rather than renting a GPU instance:
+For a judicious first deployment, keep the FastAPI service small and choose the inference path explicitly:
 
-- AWS App Runner or ECS Fargate with `0.5-1 vCPU` and `1-2 GB` RAM is enough for the FastAPI frontend/backend.
+- AWS App Runner or ECS Fargate with `0.5-1 vCPU` and `1-2 GB` RAM is enough for the FastAPI frontend/backend when inference is remote or mocked.
+- For fully local real inference, use a GPU host with enough memory for `Qwen/Qwen3-4B-Instruct-2507` plus the PEFT adapter, then set `STEALTHRL_DEMO_INFERENCE_BACKEND=hf`.
 - Mount persistent storage only for `STEALTHRL_DEMO_DB_PATH` if you need quota counters to survive container replacement; otherwise use a small managed database later.
-- Store `TINKER_API_KEY`, `STEALTHRL_DEMO_API_KEYS`, and checkpoint path/JSON in AWS Secrets Manager or the service secret-env mechanism.
+- Store `STEALTHRL_DEMO_API_KEYS` and any provider credentials in AWS Secrets Manager or the service secret-env mechanism.
 - Set `STEALTHRL_DEMO_PUBLIC_QUOTA_SCOPE=global` if you want a hard public cost cap across all unauthenticated users instead of a per-IP quota.
 
-If you later want fully local inference on AWS, use a GPU instance only after measuring Tinker latency/cost. A CPU web service plus remote sampler is the cheapest credible demo architecture.
+If you later add a hosted remote sampler, keep the web tier CPU-only and call that sampler from the backend. The current real local path is the Hugging Face PEFT backend.
 
 ## API
 

--- a/demo/README.md
+++ b/demo/README.md
@@ -1,0 +1,110 @@
+# StealthRL Demo Website
+
+This is a lightweight FastAPI demo for StealthRL. It serves a static single-page UI and exposes a small JSON API for paraphrasing text.
+
+The demo is designed to be cheap by default:
+
+- `mock` backend is zero-cost and deterministic for UI/local testing.
+- `tinker` backend lazily calls the released StealthRL sampler through Tinker when configured.
+- unauthenticated users are limited to 20 public responses per day by default.
+- API-key users can bypass the public quota or receive their own daily quota.
+
+## Run Locally
+
+```bash
+python -m venv .venv-demo
+source .venv-demo/bin/activate
+pip install -r demo/requirements.txt
+uvicorn demo.stealthrl_demo.app:app --reload --port 8080
+```
+
+Then open `http://localhost:8080`.
+
+## Configure Access
+
+Copy `demo/.env.example` to `demo/.env` or export environment variables.
+
+```bash
+export STEALTHRL_DEMO_PUBLIC_DAILY_LIMIT=20
+export STEALTHRL_DEMO_PUBLIC_QUOTA_SCOPE=ip
+export STEALTHRL_DEMO_API_KEYS='{"stealth-demo-lab":{"label":"lab","daily_limit":500}}'
+```
+
+Clients can pass API keys as either:
+
+```http
+Authorization: Bearer stealth-demo-lab
+```
+
+or:
+
+```http
+X-StealthRL-API-Key: stealth-demo-lab
+```
+
+The quota database stores only daily counters keyed by hashed identifiers; it does not store submitted text.
+
+## Use Real StealthRL Inference
+
+The default `mock` backend is intentionally cost-free. To call the actual StealthRL sampler:
+
+```bash
+export STEALTHRL_DEMO_INFERENCE_BACKEND=tinker
+export STEALTHRL_DEMO_CHECKPOINT_JSON=/path/to/m2_checkpoint.json
+export TINKER_API_KEY=...
+uvicorn demo.stealthrl_demo.app:app --host 0.0.0.0 --port 8080
+```
+
+The checkpoint JSON must contain the `checkpoints.sampler_weights` field used by `eval.methods.stealthrl.StealthRLTinker`.
+
+## Docker
+
+```bash
+docker build -f demo/Dockerfile -t stealthrl-demo .
+docker run --rm -p 8080:8080 --env-file demo/.env stealthrl-demo
+```
+
+## AWS Deployment Notes
+
+For a judicious first deployment, use a small CPU container service and Tinker-backed inference rather than renting a GPU instance:
+
+- AWS App Runner or ECS Fargate with `0.5-1 vCPU` and `1-2 GB` RAM is enough for the FastAPI frontend/backend.
+- Mount persistent storage only for `STEALTHRL_DEMO_DB_PATH` if you need quota counters to survive container replacement; otherwise use a small managed database later.
+- Store `TINKER_API_KEY`, `STEALTHRL_DEMO_API_KEYS`, and checkpoint path/JSON in AWS Secrets Manager or the service secret-env mechanism.
+- Set `STEALTHRL_DEMO_PUBLIC_QUOTA_SCOPE=global` if you want a hard public cost cap across all unauthenticated users instead of a per-IP quota.
+
+If you later want fully local inference on AWS, use a GPU instance only after measuring Tinker latency/cost. A CPU web service plus remote sampler is the cheapest credible demo architecture.
+
+## API
+
+`POST /api/paraphrase`
+
+```json
+{
+  "text": "Paste AI-generated text here...",
+  "temperature": 0.9,
+  "top_p": 0.95
+}
+```
+
+Response:
+
+```json
+{
+  "request_id": "...",
+  "input_text": "...",
+  "output_text": "...",
+  "backend": "mock",
+  "metrics": {
+    "input_words": 50,
+    "output_words": 49,
+    "word_delta_pct": -2.0,
+    "char_edit_rate": 0.41
+  },
+  "quota": {
+    "authenticated": false,
+    "limit": 20,
+    "remaining": 19
+  }
+}
+```

--- a/demo/README.md
+++ b/demo/README.md
@@ -97,8 +97,8 @@ If you later add a hosted remote sampler, keep the web tier CPU-only and call th
 ```json
 {
   "text": "Paste AI-generated text here...",
-  "temperature": 0.9,
-  "top_p": 0.95
+  "temperature": 1.0,
+  "top_p": 0.9
 }
 ```
 

--- a/demo/__init__.py
+++ b/demo/__init__.py
@@ -1,0 +1,1 @@
+"""StealthRL demo package."""

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  stealthrl-demo:
+    build:
+      context: ..
+      dockerfile: demo/Dockerfile
+    env_file:
+      - .env
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./data:/app/demo/data

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,0 +1,5 @@
+fastapi>=0.110.0
+uvicorn[standard]>=0.30.0
+pydantic>=2.7.0
+python-dotenv>=1.0.0
+tinker

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]>=0.30.0
 pydantic>=2.7.0
 python-dotenv>=1.0.0
 tinker
+peft>=0.19.0

--- a/demo/static/app.js
+++ b/demo/static/app.js
@@ -6,10 +6,8 @@ const outputActionNote = document.querySelector("#outputActionNote");
 const originalText = document.querySelector("#originalText");
 const statusLine = document.querySelector("#statusLine");
 const quotaPill = document.querySelector("#quotaPill");
-const backendPill = document.querySelector("#backendPill");
 const metricGrid = document.querySelector("#metricGrid");
 const submitButton = document.querySelector("#submitButton");
-const sampleButton = document.querySelector("#sampleButton");
 const sampleOptions = document.querySelectorAll("[data-sample]");
 const apiKey = document.querySelector("#apiKey");
 const temperature = document.querySelector("#temperature");
@@ -19,6 +17,9 @@ const topPValue = document.querySelector("#topPValue");
 const resultPanel = document.querySelector("#resultPanel");
 const progressBar = document.querySelector("#progressBar");
 const detectorButtons = document.querySelectorAll("[data-detector-url]");
+const feedbackRow = document.querySelector("#feedbackRow");
+const feedbackButtons = document.querySelectorAll("[data-feedback-rating]");
+const feedbackStatus = document.querySelector("#feedbackStatus");
 const apiBaseUrl = getApiBaseUrl();
 
 const samples = [
@@ -29,6 +30,7 @@ const samples = [
 
 let sampleIndex = 0;
 let latestOutput = "";
+let latestRequestId = "";
 
 function setStatus(message, tone = "neutral") {
   statusLine.textContent = message;
@@ -47,6 +49,11 @@ function apiUrl(path) {
 function setOutputText(message, placeholder = false) {
   outputBody.textContent = message;
   outputText.classList.toggle("placeholder", placeholder);
+}
+
+function appendOutputText(piece) {
+  outputBody.textContent += piece;
+  outputText.classList.remove("placeholder");
 }
 
 function setOutputAction(message, tone = "neutral") {
@@ -89,6 +96,15 @@ function setDetectorButtonsEnabled(enabled) {
   });
 }
 
+function setFeedbackEnabled(enabled) {
+  feedbackRow.hidden = !enabled;
+  feedbackButtons.forEach((button) => {
+    button.disabled = !enabled;
+    button.removeAttribute("aria-pressed");
+  });
+  feedbackStatus.textContent = "";
+}
+
 function getHeaders() {
   const headers = { "Content-Type": "application/json" };
   const key = apiKey.value.trim();
@@ -109,18 +125,102 @@ function loadSample(index) {
   sourceText.focus();
 }
 
+function startColdStartHints() {
+  const timers = [
+    setTimeout(() => {
+      setStatus("Azure GPU is likely waking from zero. Keep this tab open; first load can take a few minutes.", "busy");
+    }, 9000),
+    setTimeout(() => {
+      setOutputAction(
+        "Still waiting? The model server may be cold-starting. You can leave this tab open and come back in a few minutes.",
+        "neutral"
+      );
+    }, 30000)
+  ];
+  return () => timers.forEach((timer) => clearTimeout(timer));
+}
+
 async function refreshConfig() {
   try {
     const response = await fetch(apiUrl("/api/config"));
     if (!response.ok) throw new Error("config failed");
     const config = await response.json();
     quotaPill.textContent = formatQuota(config.public_quota);
-    backendPill.textContent = `backend: ${config.backend}`;
     sourceText.maxLength = config.max_chars || 5000;
   } catch (error) {
     quotaPill.textContent = "quota unavailable";
-    backendPill.textContent = "backend: unknown";
   }
+}
+
+async function parseErrorResponse(response) {
+  try {
+    const data = await response.json();
+    return data.detail || data.message || "Request failed";
+  } catch (error) {
+    return `Request failed (${response.status})`;
+  }
+}
+
+function applyFinalResult(data) {
+  clearOutputAction();
+  setOutputText(data.output_text || "No output generated.", !data.output_text);
+  latestOutput = data.output_text || "";
+  latestRequestId = data.request_id || "";
+  originalText.textContent = data.input_text || sourceText.value.trim();
+  quotaPill.textContent = formatQuota(data.quota);
+  updateMetrics(data);
+  setDetectorButtonsEnabled(Boolean(latestOutput));
+  setFeedbackEnabled(Boolean(latestRequestId));
+  setStatus(`Completed request ${latestRequestId.slice(0, 8)}.`, "done");
+}
+
+async function handleStream(response) {
+  if (!response.body) {
+    throw new Error("Streaming is not available in this browser.");
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let sawDelta = false;
+  let sawFinal = false;
+
+  const handleLine = (line) => {
+    if (!line.trim()) return;
+    const data = JSON.parse(line);
+    if (data.event === "status") {
+      setStatus(data.message || "Running...", data.tone || "busy");
+      return;
+    }
+    if (data.event === "delta") {
+      if (!sawDelta) {
+        setOutputText("");
+        sawDelta = true;
+      }
+      appendOutputText(data.text || "");
+      return;
+    }
+    if (data.event === "final") {
+      sawFinal = true;
+      applyFinalResult(data);
+      return;
+    }
+    if (data.event === "error") {
+      throw new Error(data.message || "Inference failed.");
+    }
+  };
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() || "";
+    for (const line of lines) handleLine(line);
+  }
+  buffer += decoder.decode();
+  if (buffer.trim()) handleLine(buffer);
+  if (!sawFinal) throw new Error("Stream ended before the final result arrived.");
 }
 
 async function submitDemo(event) {
@@ -132,14 +232,17 @@ async function submitDemo(event) {
   resultPanel.hidden = false;
   submitButton.disabled = true;
   setDetectorButtonsEnabled(false);
+  setFeedbackEnabled(false);
   latestOutput = "";
+  latestRequestId = "";
   clearOutputAction();
-  setOutputText("Running StealthRL paraphrasing...", true);
+  setOutputText("Starting StealthRL...", true);
   setStatus("Submitting request...", "busy");
   setProgress(true);
+  const clearColdStartHints = startColdStartHints();
 
   try {
-    const response = await fetch(apiUrl("/api/paraphrase"), {
+    const response = await fetch(apiUrl("/api/paraphrase/stream"), {
       method: "POST",
       headers: getHeaders(),
       body: JSON.stringify({
@@ -149,25 +252,17 @@ async function submitDemo(event) {
       })
     });
 
-    const data = await response.json();
     if (!response.ok) {
-      throw new Error(data.detail || "Request failed");
+      throw new Error(await parseErrorResponse(response));
     }
 
-    clearOutputAction();
-    setOutputText(data.output_text);
-    latestOutput = data.output_text;
-    originalText.textContent = data.input_text;
-    quotaPill.textContent = formatQuota(data.quota);
-    backendPill.textContent = `backend: ${data.backend}`;
-    updateMetrics(data);
-    setDetectorButtonsEnabled(true);
-    setStatus(`Completed request ${data.request_id.slice(0, 8)}.`, "done");
+    await handleStream(response);
   } catch (error) {
     clearOutputAction();
     setOutputText("No output generated.", true);
     setStatus(error.message || "Something went wrong.", "error");
   } finally {
+    clearColdStartHints();
     submitButton.disabled = false;
     setProgress(false);
   }
@@ -193,6 +288,35 @@ async function copyAndOpenDetector(event) {
   window.open(url, "_blank", "noopener,noreferrer");
 }
 
+async function submitFeedback(event) {
+  const rating = event.currentTarget.dataset.feedbackRating;
+  if (!latestRequestId || !rating) return;
+
+  feedbackButtons.forEach((button) => {
+    button.disabled = true;
+    button.setAttribute("aria-pressed", String(button.dataset.feedbackRating === rating));
+  });
+  feedbackStatus.textContent = "Sending...";
+
+  try {
+    const response = await fetch(apiUrl("/api/feedback"), {
+      method: "POST",
+      headers: getHeaders(),
+      body: JSON.stringify({
+        request_id: latestRequestId,
+        rating
+      })
+    });
+    if (!response.ok) throw new Error(await parseErrorResponse(response));
+    feedbackStatus.textContent = "Thanks.";
+  } catch (error) {
+    feedbackStatus.textContent = "Could not save.";
+    feedbackButtons.forEach((button) => {
+      button.disabled = false;
+    });
+  }
+}
+
 function bindRange(input, output) {
   const update = () => {
     output.textContent = Number(input.value).toFixed(2);
@@ -202,17 +326,20 @@ function bindRange(input, output) {
 }
 
 form.addEventListener("submit", submitDemo);
-sampleButton.addEventListener("click", () => loadSample(sampleIndex + 1));
 sampleOptions.forEach((button) => {
   button.addEventListener("click", () => loadSample(Number(button.dataset.sample)));
 });
 detectorButtons.forEach((button) => {
   button.addEventListener("click", copyAndOpenDetector);
 });
+feedbackButtons.forEach((button) => {
+  button.addEventListener("click", submitFeedback);
+});
 bindRange(temperature, temperatureValue);
 bindRange(topP, topPValue);
 
 apiKey.value = localStorage.getItem("stealthrl_demo_api_key") || "";
 setDetectorButtonsEnabled(false);
+setFeedbackEnabled(false);
 markActiveSample();
 refreshConfig();

--- a/demo/static/app.js
+++ b/demo/static/app.js
@@ -8,11 +8,14 @@ const backendPill = document.querySelector("#backendPill");
 const metricGrid = document.querySelector("#metricGrid");
 const submitButton = document.querySelector("#submitButton");
 const sampleButton = document.querySelector("#sampleButton");
+const sampleOptions = document.querySelectorAll("[data-sample]");
 const apiKey = document.querySelector("#apiKey");
 const temperature = document.querySelector("#temperature");
 const temperatureValue = document.querySelector("#temperatureValue");
 const topP = document.querySelector("#topP");
 const topPValue = document.querySelector("#topPValue");
+const resultPanel = document.querySelector("#resultPanel");
+const progressBar = document.querySelector("#progressBar");
 
 const samples = [
   "AI-text detectors are increasingly used in high-stakes settings, but their robustness to adversarial rewriting remains uncertain. StealthRL trains a paraphrase policy that preserves semantic content while reducing detector confidence, exposing how brittle many current detection systems can be under realistic paraphrasing pressure.",
@@ -25,6 +28,11 @@ let sampleIndex = 0;
 function setStatus(message, tone = "neutral") {
   statusLine.textContent = message;
   statusLine.dataset.tone = tone;
+}
+
+function setProgress(running) {
+  progressBar.classList.toggle("is-running", running);
+  progressBar.style.width = running ? "100%" : "0%";
 }
 
 function formatQuota(quota) {
@@ -51,6 +59,19 @@ function getHeaders() {
   return headers;
 }
 
+function markActiveSample() {
+  sampleOptions.forEach((button) => {
+    button.setAttribute("aria-pressed", String(Number(button.dataset.sample) === sampleIndex));
+  });
+}
+
+function loadSample(index) {
+  sampleIndex = index % samples.length;
+  sourceText.value = samples[sampleIndex];
+  markActiveSample();
+  sourceText.focus();
+}
+
 async function refreshConfig() {
   try {
     const response = await fetch("/api/config");
@@ -71,10 +92,12 @@ async function submitDemo(event) {
   if (!text) return;
 
   localStorage.setItem("stealthrl_demo_api_key", apiKey.value.trim());
+  resultPanel.hidden = false;
   submitButton.disabled = true;
   outputText.classList.add("placeholder");
   outputText.textContent = "Running StealthRL paraphrasing...";
   setStatus("Submitting request...", "busy");
+  setProgress(true);
 
   try {
     const response = await fetch("/api/paraphrase", {
@@ -105,18 +128,12 @@ async function submitDemo(event) {
     setStatus(error.message || "Something went wrong.", "error");
   } finally {
     submitButton.disabled = false;
+    setProgress(false);
   }
-}
-
-function rotateSample() {
-  sampleIndex = (sampleIndex + 1) % samples.length;
-  sourceText.value = samples[sampleIndex];
-  sourceText.focus();
 }
 
 function bindRange(input, output) {
   const update = () => {
-    output.value = Number(input.value).toFixed(2);
     output.textContent = Number(input.value).toFixed(2);
   };
   input.addEventListener("input", update);
@@ -124,9 +141,13 @@ function bindRange(input, output) {
 }
 
 form.addEventListener("submit", submitDemo);
-sampleButton.addEventListener("click", rotateSample);
+sampleButton.addEventListener("click", () => loadSample(sampleIndex + 1));
+sampleOptions.forEach((button) => {
+  button.addEventListener("click", () => loadSample(Number(button.dataset.sample)));
+});
 bindRange(temperature, temperatureValue);
 bindRange(topP, topPValue);
 
 apiKey.value = localStorage.getItem("stealthrl_demo_api_key") || "";
+markActiveSample();
 refreshConfig();

--- a/demo/static/app.js
+++ b/demo/static/app.js
@@ -147,18 +147,18 @@ async function submitDemo(event) {
 async function copyAndOpenDetector(event) {
   const target = event.currentTarget;
   const url = target.dataset.detectorUrl;
+  const label = target.dataset.detectorName || target.textContent.trim();
   if (!url || !latestOutput) return;
 
   try {
     await navigator.clipboard.writeText(latestOutput);
-    setStatus(`Copied output. Opening ${target.textContent} in a new tab.`, "done");
+    setStatus(`Copied output. Opening ${label} in a new tab.`, "done");
   } catch (error) {
-    setStatus(`Opening ${target.textContent}. Copy failed, so paste manually from the output box.`, "error");
+    setStatus(`Opening ${label}. Copy failed, so paste manually from the output box.`, "error");
   }
 
   window.open(url, "_blank", "noopener,noreferrer");
 }
-
 
 function bindRange(input, output) {
   const update = () => {

--- a/demo/static/app.js
+++ b/demo/static/app.js
@@ -1,6 +1,8 @@
 const form = document.querySelector("#demoForm");
 const sourceText = document.querySelector("#sourceText");
 const outputText = document.querySelector("#outputText");
+const outputBody = document.querySelector("#outputBody");
+const outputActionNote = document.querySelector("#outputActionNote");
 const originalText = document.querySelector("#originalText");
 const statusLine = document.querySelector("#statusLine");
 const quotaPill = document.querySelector("#quotaPill");
@@ -30,6 +32,23 @@ let latestOutput = "";
 function setStatus(message, tone = "neutral") {
   statusLine.textContent = message;
   statusLine.dataset.tone = tone;
+}
+
+function setOutputText(message, placeholder = false) {
+  outputBody.textContent = message;
+  outputText.classList.toggle("placeholder", placeholder);
+}
+
+function setOutputAction(message, tone = "neutral") {
+  outputActionNote.textContent = message;
+  outputActionNote.dataset.tone = tone;
+  outputActionNote.hidden = false;
+}
+
+function clearOutputAction() {
+  outputActionNote.hidden = true;
+  outputActionNote.textContent = "";
+  delete outputActionNote.dataset.tone;
 }
 
 function setProgress(running) {
@@ -104,8 +123,8 @@ async function submitDemo(event) {
   submitButton.disabled = true;
   setDetectorButtonsEnabled(false);
   latestOutput = "";
-  outputText.classList.add("placeholder");
-  outputText.textContent = "Running StealthRL paraphrasing...";
+  clearOutputAction();
+  setOutputText("Running StealthRL paraphrasing...", true);
   setStatus("Submitting request...", "busy");
   setProgress(true);
 
@@ -125,8 +144,8 @@ async function submitDemo(event) {
       throw new Error(data.detail || "Request failed");
     }
 
-    outputText.classList.remove("placeholder");
-    outputText.textContent = data.output_text;
+    clearOutputAction();
+    setOutputText(data.output_text);
     latestOutput = data.output_text;
     originalText.textContent = data.input_text;
     quotaPill.textContent = formatQuota(data.quota);
@@ -135,8 +154,8 @@ async function submitDemo(event) {
     setDetectorButtonsEnabled(true);
     setStatus(`Completed request ${data.request_id.slice(0, 8)}.`, "done");
   } catch (error) {
-    outputText.classList.add("placeholder");
-    outputText.textContent = "No output generated.";
+    clearOutputAction();
+    setOutputText("No output generated.", true);
     setStatus(error.message || "Something went wrong.", "error");
   } finally {
     submitButton.disabled = false;
@@ -152,9 +171,13 @@ async function copyAndOpenDetector(event) {
 
   try {
     await navigator.clipboard.writeText(latestOutput);
-    setStatus(`Copied output. Opening ${label} in a new tab.`, "done");
+    const message = `Copied output. Opening ${label} in a new tab.`;
+    setStatus(message, "done");
+    setOutputAction(message, "done");
   } catch (error) {
-    setStatus(`Opening ${label}. Copy failed, so paste manually from the output box.`, "error");
+    const message = `Opening ${label}. Copy failed, so paste manually from the output box.`;
+    setStatus(message, "error");
+    setOutputAction(message, "error");
   }
 
   window.open(url, "_blank", "noopener,noreferrer");

--- a/demo/static/app.js
+++ b/demo/static/app.js
@@ -1,0 +1,132 @@
+const form = document.querySelector("#demoForm");
+const sourceText = document.querySelector("#sourceText");
+const outputText = document.querySelector("#outputText");
+const originalText = document.querySelector("#originalText");
+const statusLine = document.querySelector("#statusLine");
+const quotaPill = document.querySelector("#quotaPill");
+const backendPill = document.querySelector("#backendPill");
+const metricGrid = document.querySelector("#metricGrid");
+const submitButton = document.querySelector("#submitButton");
+const sampleButton = document.querySelector("#sampleButton");
+const apiKey = document.querySelector("#apiKey");
+const temperature = document.querySelector("#temperature");
+const temperatureValue = document.querySelector("#temperatureValue");
+const topP = document.querySelector("#topP");
+const topPValue = document.querySelector("#topPValue");
+
+const samples = [
+  "AI-text detectors are increasingly used in high-stakes settings, but their robustness to adversarial rewriting remains uncertain. StealthRL trains a paraphrase policy that preserves semantic content while reducing detector confidence, exposing how brittle many current detection systems can be under realistic paraphrasing pressure.",
+  "Universities and publishers often rely on automated detectors to identify machine-written text. These systems may work on clean examples, but an adaptive writer can revise sentence structure, vocabulary, and rhythm while keeping the same meaning. A robust evaluation should measure how detection behaves under that pressure.",
+  "The experiment evaluates six attack settings on the full filtered MAGE test pool. StealthRL achieves low detector recall at strict false-positive operating points while retaining enough semantic similarity to illustrate a practical evasion-quality tradeoff."
+];
+
+let sampleIndex = 0;
+
+function setStatus(message, tone = "neutral") {
+  statusLine.textContent = message;
+  statusLine.dataset.tone = tone;
+}
+
+function formatQuota(quota) {
+  if (!quota) return "quota unavailable";
+  if (quota.authenticated && quota.limit === null) return "API key: unlimited";
+  if (quota.authenticated) return `API key: ${quota.remaining}/${quota.limit} left`;
+  return `public: ${quota.remaining}/${quota.limit} left`;
+}
+
+function updateMetrics(data) {
+  const metrics = data.metrics || {};
+  metricGrid.innerHTML = `
+    <div><span>Input words</span><strong>${metrics.input_words ?? "-"}</strong></div>
+    <div><span>Output words</span><strong>${metrics.output_words ?? "-"}</strong></div>
+    <div><span>Edit rate</span><strong>${metrics.char_edit_rate ?? "-"}</strong></div>
+    <div><span>Latency</span><strong>${data.latency_ms ?? "-"} ms</strong></div>
+  `;
+}
+
+function getHeaders() {
+  const headers = { "Content-Type": "application/json" };
+  const key = apiKey.value.trim();
+  if (key) headers.Authorization = `Bearer ${key}`;
+  return headers;
+}
+
+async function refreshConfig() {
+  try {
+    const response = await fetch("/api/config");
+    if (!response.ok) throw new Error("config failed");
+    const config = await response.json();
+    quotaPill.textContent = formatQuota(config.public_quota);
+    backendPill.textContent = `backend: ${config.backend}`;
+    sourceText.maxLength = config.max_chars || 5000;
+  } catch (error) {
+    quotaPill.textContent = "quota unavailable";
+    backendPill.textContent = "backend: unknown";
+  }
+}
+
+async function submitDemo(event) {
+  event.preventDefault();
+  const text = sourceText.value.trim();
+  if (!text) return;
+
+  localStorage.setItem("stealthrl_demo_api_key", apiKey.value.trim());
+  submitButton.disabled = true;
+  outputText.classList.add("placeholder");
+  outputText.textContent = "Running StealthRL paraphrasing...";
+  setStatus("Submitting request...", "busy");
+
+  try {
+    const response = await fetch("/api/paraphrase", {
+      method: "POST",
+      headers: getHeaders(),
+      body: JSON.stringify({
+        text,
+        temperature: Number(temperature.value),
+        top_p: Number(topP.value)
+      })
+    });
+
+    const data = await response.json();
+    if (!response.ok) {
+      throw new Error(data.detail || "Request failed");
+    }
+
+    outputText.classList.remove("placeholder");
+    outputText.textContent = data.output_text;
+    originalText.textContent = data.input_text;
+    quotaPill.textContent = formatQuota(data.quota);
+    backendPill.textContent = `backend: ${data.backend}`;
+    updateMetrics(data);
+    setStatus(`Completed request ${data.request_id.slice(0, 8)}.`, "done");
+  } catch (error) {
+    outputText.classList.add("placeholder");
+    outputText.textContent = "No output generated.";
+    setStatus(error.message || "Something went wrong.", "error");
+  } finally {
+    submitButton.disabled = false;
+  }
+}
+
+function rotateSample() {
+  sampleIndex = (sampleIndex + 1) % samples.length;
+  sourceText.value = samples[sampleIndex];
+  sourceText.focus();
+}
+
+function bindRange(input, output) {
+  const update = () => {
+    output.value = Number(input.value).toFixed(2);
+    output.textContent = Number(input.value).toFixed(2);
+  };
+  input.addEventListener("input", update);
+  update();
+}
+
+form.addEventListener("submit", submitDemo);
+sampleButton.addEventListener("click", rotateSample);
+bindRange(temperature, temperatureValue);
+bindRange(topP, topPValue);
+
+apiKey.value = localStorage.getItem("stealthrl_demo_api_key") || "";
+refreshConfig();

--- a/demo/static/app.js
+++ b/demo/static/app.js
@@ -16,6 +16,7 @@ const topP = document.querySelector("#topP");
 const topPValue = document.querySelector("#topPValue");
 const resultPanel = document.querySelector("#resultPanel");
 const progressBar = document.querySelector("#progressBar");
+const detectorButtons = document.querySelectorAll("[data-detector-url]");
 
 const samples = [
   "AI-text detectors are increasingly used in high-stakes settings, but their robustness to adversarial rewriting remains uncertain. StealthRL trains a paraphrase policy that preserves semantic content while reducing detector confidence, exposing how brittle many current detection systems can be under realistic paraphrasing pressure.",
@@ -24,6 +25,7 @@ const samples = [
 ];
 
 let sampleIndex = 0;
+let latestOutput = "";
 
 function setStatus(message, tone = "neutral") {
   statusLine.textContent = message;
@@ -50,6 +52,12 @@ function updateMetrics(data) {
     <div><span>Edit rate</span><strong>${metrics.char_edit_rate ?? "-"}</strong></div>
     <div><span>Latency</span><strong>${data.latency_ms ?? "-"} ms</strong></div>
   `;
+}
+
+function setDetectorButtonsEnabled(enabled) {
+  detectorButtons.forEach((button) => {
+    button.disabled = !enabled;
+  });
 }
 
 function getHeaders() {
@@ -94,6 +102,8 @@ async function submitDemo(event) {
   localStorage.setItem("stealthrl_demo_api_key", apiKey.value.trim());
   resultPanel.hidden = false;
   submitButton.disabled = true;
+  setDetectorButtonsEnabled(false);
+  latestOutput = "";
   outputText.classList.add("placeholder");
   outputText.textContent = "Running StealthRL paraphrasing...";
   setStatus("Submitting request...", "busy");
@@ -117,10 +127,12 @@ async function submitDemo(event) {
 
     outputText.classList.remove("placeholder");
     outputText.textContent = data.output_text;
+    latestOutput = data.output_text;
     originalText.textContent = data.input_text;
     quotaPill.textContent = formatQuota(data.quota);
     backendPill.textContent = `backend: ${data.backend}`;
     updateMetrics(data);
+    setDetectorButtonsEnabled(true);
     setStatus(`Completed request ${data.request_id.slice(0, 8)}.`, "done");
   } catch (error) {
     outputText.classList.add("placeholder");
@@ -131,6 +143,22 @@ async function submitDemo(event) {
     setProgress(false);
   }
 }
+
+async function copyAndOpenDetector(event) {
+  const target = event.currentTarget;
+  const url = target.dataset.detectorUrl;
+  if (!url || !latestOutput) return;
+
+  try {
+    await navigator.clipboard.writeText(latestOutput);
+    setStatus(`Copied output. Opening ${target.textContent} in a new tab.`, "done");
+  } catch (error) {
+    setStatus(`Opening ${target.textContent}. Copy failed, so paste manually from the output box.`, "error");
+  }
+
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
 
 function bindRange(input, output) {
   const update = () => {
@@ -145,9 +173,13 @@ sampleButton.addEventListener("click", () => loadSample(sampleIndex + 1));
 sampleOptions.forEach((button) => {
   button.addEventListener("click", () => loadSample(Number(button.dataset.sample)));
 });
+detectorButtons.forEach((button) => {
+  button.addEventListener("click", copyAndOpenDetector);
+});
 bindRange(temperature, temperatureValue);
 bindRange(topP, topPValue);
 
 apiKey.value = localStorage.getItem("stealthrl_demo_api_key") || "";
+setDetectorButtonsEnabled(false);
 markActiveSample();
 refreshConfig();

--- a/demo/static/app.js
+++ b/demo/static/app.js
@@ -21,9 +21,9 @@ const progressBar = document.querySelector("#progressBar");
 const detectorButtons = document.querySelectorAll("[data-detector-url]");
 
 const samples = [
-  "AI-text detectors are increasingly used in high-stakes settings, but their robustness to adversarial rewriting remains uncertain. StealthRL trains a paraphrase policy that preserves semantic content while reducing detector confidence, exposing how brittle many current detection systems can be under realistic paraphrasing pressure.",
-  "Universities and publishers often rely on automated detectors to identify machine-written text. These systems may work on clean examples, but an adaptive writer can revise sentence structure, vocabulary, and rhythm while keeping the same meaning. A robust evaluation should measure how detection behaves under that pressure.",
-  "The experiment evaluates six attack settings on the full filtered MAGE test pool. StealthRL achieves low detector recall at strict false-positive operating points while retaining enough semantic similarity to illustrate a practical evasion-quality tradeoff."
+  "During sustained cardio exercise, the heart increases its workload and the rest of the body adjusts to support that effort. Blood vessels widen to improve circulation, leg and core muscles help push blood back toward the heart, and the lungs breathe faster to bring in oxygen while clearing waste gases such as carbon dioxide throughout the workout and recovery period.",
+  "Photosynthesis converts light energy into chemical energy that plants can store inside glucose molecules. The process occurs in chloroplasts and unfolds in two linked stages: light-dependent reactions capture sunlight and split water, while the Calvin cycle uses that energy to build sugars that support plant growth, cellular repair, and long-term energy storage during changing seasons and environmental stress across ecosystems.",
+  "Solar and wind power have become far cheaper over the past decade, allowing renewable energy to compete with fossil fuels in many electricity markets. Better storage systems, improved grid planning, public incentives, and larger manufacturing pipelines continue to accelerate adoption, while utilities weigh reliability, cost, emissions targets, and regional demand in their long-term investment decisions for new infrastructure projects nationwide."
 ];
 
 let sampleIndex = 0;

--- a/demo/static/app.js
+++ b/demo/static/app.js
@@ -19,6 +19,7 @@ const topPValue = document.querySelector("#topPValue");
 const resultPanel = document.querySelector("#resultPanel");
 const progressBar = document.querySelector("#progressBar");
 const detectorButtons = document.querySelectorAll("[data-detector-url]");
+const apiBaseUrl = getApiBaseUrl();
 
 const samples = [
   "During sustained cardio exercise, the heart increases its workload and the rest of the body adjusts to support that effort. Blood vessels widen to improve circulation, leg and core muscles help push blood back toward the heart, and the lungs breathe faster to bring in oxygen while clearing waste gases such as carbon dioxide throughout the workout and recovery period.",
@@ -32,6 +33,15 @@ let latestOutput = "";
 function setStatus(message, tone = "neutral") {
   statusLine.textContent = message;
   statusLine.dataset.tone = tone;
+}
+
+function getApiBaseUrl() {
+  const meta = document.querySelector('meta[name="stealthrl-api-base-url"]');
+  return (meta?.content || "").trim().replace(/\/$/, "");
+}
+
+function apiUrl(path) {
+  return `${apiBaseUrl}${path}`;
 }
 
 function setOutputText(message, placeholder = false) {
@@ -101,7 +111,7 @@ function loadSample(index) {
 
 async function refreshConfig() {
   try {
-    const response = await fetch("/api/config");
+    const response = await fetch(apiUrl("/api/config"));
     if (!response.ok) throw new Error("config failed");
     const config = await response.json();
     quotaPill.textContent = formatQuota(config.public_quota);
@@ -129,7 +139,7 @@ async function submitDemo(event) {
   setProgress(true);
 
   try {
-    const response = await fetch("/api/paraphrase", {
+    const response = await fetch(apiUrl("/api/paraphrase"), {
       method: "POST",
       headers: getHeaders(),
       body: JSON.stringify({

--- a/demo/static/app.js
+++ b/demo/static/app.js
@@ -185,9 +185,9 @@ async function handleStream(response) {
   let sawDelta = false;
   let sawFinal = false;
 
-  const handleLine = (line) => {
-    if (!line.trim()) return;
-    const data = JSON.parse(line);
+  const handlePayload = (payload) => {
+    if (!payload.trim()) return;
+    const data = JSON.parse(payload);
     if (data.event === "status") {
       setStatus(data.message || "Running...", data.tone || "busy");
       return;
@@ -214,13 +214,27 @@ async function handleStream(response) {
     const { value, done } = await reader.read();
     if (done) break;
     buffer += decoder.decode(value, { stream: true });
-    const lines = buffer.split("\n");
-    buffer = lines.pop() || "";
-    for (const line of lines) handleLine(line);
+    const blocks = buffer.split("\n\n");
+    buffer = blocks.pop() || "";
+    for (const block of blocks) handleStreamBlock(block, handlePayload);
   }
   buffer += decoder.decode();
-  if (buffer.trim()) handleLine(buffer);
+  if (buffer.trim()) handleStreamBlock(buffer, handlePayload);
   if (!sawFinal) throw new Error("Stream ended before the final result arrived.");
+}
+
+function handleStreamBlock(block, handlePayload) {
+  const dataLines = block
+    .split("\n")
+    .filter((line) => line.startsWith("data:"))
+    .map((line) => line.slice(5).trimStart());
+  if (dataLines.length) {
+    handlePayload(dataLines.join("\n"));
+    return;
+  }
+
+  // Local/dev fallback for newline-delimited JSON streams.
+  block.split("\n").forEach((line) => handlePayload(line));
 }
 
 async function submitDemo(event) {

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -32,8 +32,7 @@
         </p>
         <div class="disclaimer">
           <strong>Research preview.</strong>
-          Do not paste private text. Outputs are for robustness exploration, not a guarantee of
-          detector evasion.
+          Do not paste private text. Outputs are for robustness exploration, not detector-evasion guarantees.
         </div>
         <nav class="link-row" aria-label="Project links">
           <a href="https://arxiv.org/abs/2602.08934" target="_blank" rel="noreferrer">Paper</a>

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -124,8 +124,13 @@
       </section>
 
       <footer class="footer">
-        <span>StealthRL demo</span>
-        <span>FastAPI service with public quota and optional API-key access</span>
+        <span>
+          <a href="https://www.linkedin.com/in/suraj-ranganath/" target="_blank" rel="noreferrer">Suraj Ranganath</a>
+          &amp;
+          <a href="https://www.linkedin.com/in/atharv-ramesh/" target="_blank" rel="noreferrer">Atharv Ramesh</a>
+        </span>
+        <span><a href="/privacy">Privacy</a></span>
+        <span>Copyright &copy; 2026. All rights reserved.</span>
       </footer>
     </main>
 

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -6,195 +6,129 @@
     <title>StealthRL Demo</title>
     <meta
       name="description"
-      content="Interactive demo for StealthRL, a reinforcement-learning paraphrase attack for stress-testing AI-text detectors."
+      content="Interactive research demo for StealthRL, a paraphrase policy for stress-testing AI-text detectors."
     />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
       rel="stylesheet"
     />
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
-    <div class="grain" aria-hidden="true"></div>
-    <div class="orb orb-a" aria-hidden="true"></div>
-    <div class="orb orb-b" aria-hidden="true"></div>
+    <div class="bg-grid" aria-hidden="true"></div>
 
-    <header class="nav">
-      <a class="brand" href="/">
-        <span class="brand-mark">SRL</span>
-        <span>StealthRL Demo</span>
-      </a>
-      <nav class="nav-links" aria-label="Primary navigation">
-        <a href="#demo">Demo</a>
-        <a href="#method">Method</a>
-        <a href="https://arxiv.org/abs/2602.08934" target="_blank" rel="noreferrer">Paper</a>
-        <a href="https://huggingface.co/suraj-ranganath/StealthRL" target="_blank" rel="noreferrer">Model</a>
-      </nav>
-    </header>
-
-    <main>
-      <section class="hero">
-        <div class="hero-copy">
-          <p class="eyebrow">Adversarial robustness playground</p>
-          <h1>Rewrite text the way detectors wish attackers could not.</h1>
-          <p class="lede">
-            StealthRL is a reinforcement-learning paraphrase policy trained to preserve meaning
-            while stress-testing AI-text detectors. This demo lets you run a bounded public preview
-            or use an API key for extended access.
-          </p>
-          <div class="hero-actions">
-            <a class="button primary" href="#demo">Try the demo</a>
-            <a class="button ghost" href="#method">How it works</a>
-          </div>
+    <main class="wrap">
+      <header class="hero">
+        <p class="kicker">RESEARCH DEMO</p>
+        <div class="title-row">
+          <span class="brand-mark">SRL</span>
+          <h1>StealthRL</h1>
         </div>
-        <aside class="hero-card" aria-label="Research result summary">
-          <div class="metric-ring">
-            <span class="metric-value">97.6%</span>
-            <span class="metric-label">attack success rate</span>
-          </div>
-          <div class="metric-list">
-            <div>
-              <span>Mean TPR@1%FPR</span>
-              <strong>0.024</strong>
-            </div>
-            <div>
-              <span>Detector panel</span>
-              <strong>4 families</strong>
-            </div>
-            <div>
-              <span>Evaluation pool</span>
-              <strong>29,966 texts</strong>
-            </div>
-          </div>
-        </aside>
-      </section>
+        <p class="subtitle">
+          A compact interface for running the StealthRL paraphrase policy and inspecting the
+          rewritten text. Public access is intentionally rate-limited.
+        </p>
+        <div class="disclaimer">
+          <strong>Research preview.</strong>
+          Do not paste private text. Outputs are for robustness exploration, not a guarantee of
+          detector evasion.
+        </div>
+        <nav class="link-row" aria-label="Project links">
+          <a href="https://arxiv.org/abs/2602.08934" target="_blank" rel="noreferrer">Paper</a>
+          <a href="https://huggingface.co/suraj-ranganath/StealthRL" target="_blank" rel="noreferrer">Model</a>
+          <a href="https://github.com/suraj-ranganath/StealthRL" target="_blank" rel="noreferrer">GitHub</a>
+        </nav>
+      </header>
 
-      <section class="demo-grid" id="demo">
-        <form class="panel input-panel" id="demoForm">
-          <div class="panel-heading">
-            <div>
-              <p class="eyebrow">Interactive rewrite</p>
-              <h2>Paste AI-written text</h2>
-            </div>
-            <span class="quota-pill" id="quotaPill">Loading quota...</span>
+      <form class="panel" id="demoForm">
+        <div class="panel-head">
+          <div>
+            <p class="section-label">Input</p>
+            <h2>Text to paraphrase</h2>
           </div>
+          <span class="pill" id="quotaPill">Loading quota...</span>
+        </div>
 
-          <label class="field">
-            <span>Source text</span>
-            <textarea
-              id="sourceText"
-              name="text"
-              minlength="20"
-              maxlength="5000"
-              required
-              spellcheck="true"
-            >AI-text detectors are increasingly used in high-stakes settings, but their robustness to adversarial rewriting remains uncertain. StealthRL trains a paraphrase policy that preserves semantic content while reducing detector confidence, exposing how brittle many current detection systems can be under realistic paraphrasing pressure.</textarea>
+        <div class="sample-row" aria-label="Sample texts">
+          <button type="button" class="sample-option" data-sample="0">Detector note</button>
+          <button type="button" class="sample-option" data-sample="1">University policy</button>
+          <button type="button" class="sample-option" data-sample="2">Experiment summary</button>
+        </div>
+
+        <label class="field" for="sourceText">Source text</label>
+        <textarea
+          id="sourceText"
+          name="text"
+          minlength="20"
+          maxlength="5000"
+          required
+          spellcheck="true"
+        >AI-text detectors are increasingly used in high-stakes settings, but their robustness to adversarial rewriting remains uncertain. StealthRL trains a paraphrase policy that preserves semantic content while reducing detector confidence, exposing how brittle many current detection systems can be under realistic paraphrasing pressure.</textarea>
+
+        <div class="settings-grid">
+          <label>
+            Temperature
+            <span id="temperatureValue">0.90</span>
+            <input id="temperature" name="temperature" type="range" min="0" max="1.5" value="0.9" step="0.05" />
           </label>
+          <label>
+            Top-p
+            <span id="topPValue">0.95</span>
+            <input id="topP" name="top_p" type="range" min="0.1" max="1" value="0.95" step="0.05" />
+          </label>
+        </div>
 
-          <div class="controls">
-            <label>
-              Temperature
-              <input id="temperature" name="temperature" type="range" min="0" max="1.5" value="0.9" step="0.05" />
-              <output id="temperatureValue">0.90</output>
-            </label>
-            <label>
-              Top-p
-              <input id="topP" name="top_p" type="range" min="0.1" max="1" value="0.95" step="0.05" />
-              <output id="topPValue">0.95</output>
-            </label>
+        <details class="api-key-box">
+          <summary>Use API key for extended access</summary>
+          <label class="field compact" for="apiKey">API key</label>
+          <input id="apiKey" type="password" placeholder="Bearer or X-StealthRL-API-Key" autocomplete="off" />
+          <p>Stored only in this browser. Public requests use the daily anonymous quota.</p>
+        </details>
+
+        <div class="action-row">
+          <button class="primary-button" type="submit" id="submitButton">Run StealthRL</button>
+          <button class="secondary-button" type="button" id="sampleButton">Next sample</button>
+          <span class="pill muted" id="backendPill">backend: unknown</span>
+        </div>
+
+        <div class="progress-wrap" aria-hidden="true">
+          <div class="progress-bar" id="progressBar"></div>
+        </div>
+        <p class="status-line" id="statusLine">Ready.</p>
+      </form>
+
+      <section class="panel result-panel" id="resultPanel" aria-label="Result" hidden>
+        <div class="panel-head">
+          <div>
+            <p class="section-label">Output</p>
+            <h2>StealthRL rewrite</h2>
           </div>
+        </div>
 
-          <details class="api-key-box">
-            <summary>Use an API key</summary>
-            <label class="field compact">
-              <span>API key</span>
-              <input id="apiKey" type="password" placeholder="Bearer or X-StealthRL-API-Key" autocomplete="off" />
-            </label>
-            <p>Keys are stored only in your browser local storage. Public requests are capped daily.</p>
-          </details>
+        <div class="result-copy" id="outputText">
+          Your paraphrase will appear here after the request completes.
+        </div>
 
-          <div class="form-actions">
-            <button class="button primary" type="submit" id="submitButton">Run StealthRL</button>
-            <button class="button ghost" type="button" id="sampleButton">Load another sample</button>
-          </div>
-          <p class="fine-print">
-            Public demo outputs are for research exploration only. Do not submit private or sensitive text.
-          </p>
-        </form>
+        <div class="metric-grid" id="metricGrid">
+          <div><span>Input words</span><strong>-</strong></div>
+          <div><span>Output words</span><strong>-</strong></div>
+          <div><span>Edit rate</span><strong>-</strong></div>
+          <div><span>Latency</span><strong>-</strong></div>
+        </div>
 
-        <section class="panel output-panel" aria-live="polite">
-          <div class="panel-heading">
-            <div>
-              <p class="eyebrow">Result</p>
-              <h2>Paraphrased output</h2>
-            </div>
-            <span class="backend-pill" id="backendPill">backend: unknown</span>
-          </div>
-
-          <div class="status-line" id="statusLine">Ready.</div>
-
-          <div class="result-card">
-            <h3>StealthRL rewrite</h3>
-            <p id="outputText" class="placeholder">
-              Your paraphrase will appear here after the request completes.
-            </p>
-          </div>
-
-          <div class="metric-grid" id="metricGrid">
-            <div><span>Input words</span><strong>-</strong></div>
-            <div><span>Output words</span><strong>-</strong></div>
-            <div><span>Edit rate</span><strong>-</strong></div>
-            <div><span>Latency</span><strong>-</strong></div>
-          </div>
-
-          <div class="compare-box">
-            <h3>Original</h3>
-            <p id="originalText" class="muted-copy">Run the demo to compare source and rewritten text.</p>
-          </div>
-        </section>
+        <details class="original-box">
+          <summary>Show original text</summary>
+          <p id="originalText">Run the demo to compare source and rewritten text.</p>
+        </details>
       </section>
 
-      <section class="method" id="method">
-        <div class="section-heading">
-          <p class="eyebrow">Architecture</p>
-          <h2>Small public surface, research-grade backend hooks.</h2>
-        </div>
-        <div class="method-grid">
-          <article>
-            <span class="step">01</span>
-            <h3>Bounded access</h3>
-            <p>
-              Unauthenticated users get a persisted daily quota. API keys can be configured with
-              separate daily limits for collaborators, reviewers, or lab demos.
-            </p>
-          </article>
-          <article>
-            <span class="step">02</span>
-            <h3>Lazy inference</h3>
-            <p>
-              The service starts cheaply. Real StealthRL sampling loads only when the Tinker backend
-              is enabled and a request arrives.
-            </p>
-          </article>
-          <article>
-            <span class="step">03</span>
-            <h3>Research context</h3>
-            <p>
-              The UI reports text-shape diagnostics and links directly to the paper and model,
-              without presenting detector evasion as a production guarantee.
-            </p>
-          </article>
-        </div>
-      </section>
+      <footer class="footer">
+        <span>StealthRL demo</span>
+        <span>FastAPI service with public quota and optional API-key access</span>
+      </footer>
     </main>
-
-    <footer class="footer">
-      <span>StealthRL</span>
-      <span>Adversarial evaluation for AI-text detectors</span>
-      <span><a href="https://github.com/suraj-ranganath/StealthRL" target="_blank" rel="noreferrer">GitHub</a></span>
-    </footer>
 
     <script src="/static/app.js" type="module"></script>
   </body>

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -110,7 +110,8 @@
         </div>
 
         <div class="result-copy" id="outputText">
-          Your paraphrase will appear here after the request completes.
+          <div class="output-action-note" id="outputActionNote" hidden></div>
+          <div id="outputBody">Your paraphrase will appear here after the request completes.</div>
         </div>
 
         <div class="metric-grid" id="metricGrid">

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -8,6 +8,7 @@
       name="description"
       content="Interactive research demo for StealthRL, a paraphrase policy for stress-testing AI-text detectors."
     />
+    <meta name="stealthrl-api-base-url" content="" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -54,9 +54,9 @@
         </div>
 
         <div class="sample-row" aria-label="Sample texts">
-          <button type="button" class="sample-option" data-sample="0">Detector note</button>
-          <button type="button" class="sample-option" data-sample="1">University policy</button>
-          <button type="button" class="sample-option" data-sample="2">Experiment summary</button>
+          <button type="button" class="sample-option" data-sample="0">Cardio physiology</button>
+          <button type="button" class="sample-option" data-sample="1">Photosynthesis</button>
+          <button type="button" class="sample-option" data-sample="2">Renewable energy</button>
         </div>
 
         <label class="field" for="sourceText">Source text</label>
@@ -67,7 +67,7 @@
           maxlength="5000"
           required
           spellcheck="true"
-        >AI-text detectors are increasingly used in high-stakes settings, but their robustness to adversarial rewriting remains uncertain. StealthRL trains a paraphrase policy that preserves semantic content while reducing detector confidence, exposing how brittle many current detection systems can be under realistic paraphrasing pressure.</textarea>
+        >During sustained cardio exercise, the heart increases its workload and the rest of the body adjusts to support that effort. Blood vessels widen to improve circulation, leg and core muscles help push blood back toward the heart, and the lungs breathe faster to bring in oxygen while clearing waste gases such as carbon dioxide throughout the workout and recovery period.</textarea>
 
         <div class="settings-grid">
           <label>

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -27,8 +27,11 @@
           <h1>StealthRL</h1>
         </div>
         <p class="subtitle">
-          A compact interface for running the StealthRL paraphrase policy and inspecting the
-          rewritten text. Public access is intentionally rate-limited.
+          AI-text detectors are increasingly used in high-stakes settings, yet their robustness to
+          meaning-preserving adversarial rewriting remains uncertain. We introduce StealthRL, a
+          reinforcement learning framework for stress-testing AI-text detectors with adaptive
+          paraphrase attacks. StealthRL trains a paraphrase policy against a detector ensemble while
+          preserving semantic content, then evaluates transfer to held-out detector families.
         </p>
         <div class="disclaimer">
           <strong>Research preview.</strong>
@@ -108,6 +111,13 @@
 
         <div class="result-copy" id="outputText">
           Your paraphrase will appear here after the request completes.
+        </div>
+
+        <div class="detector-links" aria-label="External detector handoff">
+          <span>Copy output and open:</span>
+          <button type="button" data-detector-url="https://www.pangram.com/" disabled>Pangram</button>
+          <button type="button" data-detector-url="https://gptzero.me/" disabled>GPTZero</button>
+          <button type="button" data-detector-url="https://www.grammarly.com/ai-detector" disabled>Grammarly</button>
         </div>
 
         <div class="metric-grid" id="metricGrid">

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -1,0 +1,201 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>StealthRL Demo</title>
+    <meta
+      name="description"
+      content="Interactive demo for StealthRL, a reinforcement-learning paraphrase attack for stress-testing AI-text detectors."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700&family=Space+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <div class="grain" aria-hidden="true"></div>
+    <div class="orb orb-a" aria-hidden="true"></div>
+    <div class="orb orb-b" aria-hidden="true"></div>
+
+    <header class="nav">
+      <a class="brand" href="/">
+        <span class="brand-mark">SRL</span>
+        <span>StealthRL Demo</span>
+      </a>
+      <nav class="nav-links" aria-label="Primary navigation">
+        <a href="#demo">Demo</a>
+        <a href="#method">Method</a>
+        <a href="https://arxiv.org/abs/2602.08934" target="_blank" rel="noreferrer">Paper</a>
+        <a href="https://huggingface.co/suraj-ranganath/StealthRL" target="_blank" rel="noreferrer">Model</a>
+      </nav>
+    </header>
+
+    <main>
+      <section class="hero">
+        <div class="hero-copy">
+          <p class="eyebrow">Adversarial robustness playground</p>
+          <h1>Rewrite text the way detectors wish attackers could not.</h1>
+          <p class="lede">
+            StealthRL is a reinforcement-learning paraphrase policy trained to preserve meaning
+            while stress-testing AI-text detectors. This demo lets you run a bounded public preview
+            or use an API key for extended access.
+          </p>
+          <div class="hero-actions">
+            <a class="button primary" href="#demo">Try the demo</a>
+            <a class="button ghost" href="#method">How it works</a>
+          </div>
+        </div>
+        <aside class="hero-card" aria-label="Research result summary">
+          <div class="metric-ring">
+            <span class="metric-value">97.6%</span>
+            <span class="metric-label">attack success rate</span>
+          </div>
+          <div class="metric-list">
+            <div>
+              <span>Mean TPR@1%FPR</span>
+              <strong>0.024</strong>
+            </div>
+            <div>
+              <span>Detector panel</span>
+              <strong>4 families</strong>
+            </div>
+            <div>
+              <span>Evaluation pool</span>
+              <strong>29,966 texts</strong>
+            </div>
+          </div>
+        </aside>
+      </section>
+
+      <section class="demo-grid" id="demo">
+        <form class="panel input-panel" id="demoForm">
+          <div class="panel-heading">
+            <div>
+              <p class="eyebrow">Interactive rewrite</p>
+              <h2>Paste AI-written text</h2>
+            </div>
+            <span class="quota-pill" id="quotaPill">Loading quota...</span>
+          </div>
+
+          <label class="field">
+            <span>Source text</span>
+            <textarea
+              id="sourceText"
+              name="text"
+              minlength="20"
+              maxlength="5000"
+              required
+              spellcheck="true"
+            >AI-text detectors are increasingly used in high-stakes settings, but their robustness to adversarial rewriting remains uncertain. StealthRL trains a paraphrase policy that preserves semantic content while reducing detector confidence, exposing how brittle many current detection systems can be under realistic paraphrasing pressure.</textarea>
+          </label>
+
+          <div class="controls">
+            <label>
+              Temperature
+              <input id="temperature" name="temperature" type="range" min="0" max="1.5" value="0.9" step="0.05" />
+              <output id="temperatureValue">0.90</output>
+            </label>
+            <label>
+              Top-p
+              <input id="topP" name="top_p" type="range" min="0.1" max="1" value="0.95" step="0.05" />
+              <output id="topPValue">0.95</output>
+            </label>
+          </div>
+
+          <details class="api-key-box">
+            <summary>Use an API key</summary>
+            <label class="field compact">
+              <span>API key</span>
+              <input id="apiKey" type="password" placeholder="Bearer or X-StealthRL-API-Key" autocomplete="off" />
+            </label>
+            <p>Keys are stored only in your browser local storage. Public requests are capped daily.</p>
+          </details>
+
+          <div class="form-actions">
+            <button class="button primary" type="submit" id="submitButton">Run StealthRL</button>
+            <button class="button ghost" type="button" id="sampleButton">Load another sample</button>
+          </div>
+          <p class="fine-print">
+            Public demo outputs are for research exploration only. Do not submit private or sensitive text.
+          </p>
+        </form>
+
+        <section class="panel output-panel" aria-live="polite">
+          <div class="panel-heading">
+            <div>
+              <p class="eyebrow">Result</p>
+              <h2>Paraphrased output</h2>
+            </div>
+            <span class="backend-pill" id="backendPill">backend: unknown</span>
+          </div>
+
+          <div class="status-line" id="statusLine">Ready.</div>
+
+          <div class="result-card">
+            <h3>StealthRL rewrite</h3>
+            <p id="outputText" class="placeholder">
+              Your paraphrase will appear here after the request completes.
+            </p>
+          </div>
+
+          <div class="metric-grid" id="metricGrid">
+            <div><span>Input words</span><strong>-</strong></div>
+            <div><span>Output words</span><strong>-</strong></div>
+            <div><span>Edit rate</span><strong>-</strong></div>
+            <div><span>Latency</span><strong>-</strong></div>
+          </div>
+
+          <div class="compare-box">
+            <h3>Original</h3>
+            <p id="originalText" class="muted-copy">Run the demo to compare source and rewritten text.</p>
+          </div>
+        </section>
+      </section>
+
+      <section class="method" id="method">
+        <div class="section-heading">
+          <p class="eyebrow">Architecture</p>
+          <h2>Small public surface, research-grade backend hooks.</h2>
+        </div>
+        <div class="method-grid">
+          <article>
+            <span class="step">01</span>
+            <h3>Bounded access</h3>
+            <p>
+              Unauthenticated users get a persisted daily quota. API keys can be configured with
+              separate daily limits for collaborators, reviewers, or lab demos.
+            </p>
+          </article>
+          <article>
+            <span class="step">02</span>
+            <h3>Lazy inference</h3>
+            <p>
+              The service starts cheaply. Real StealthRL sampling loads only when the Tinker backend
+              is enabled and a request arrives.
+            </p>
+          </article>
+          <article>
+            <span class="step">03</span>
+            <h3>Research context</h3>
+            <p>
+              The UI reports text-shape diagnostics and links directly to the paper and model,
+              without presenting detector evasion as a production guarantee.
+            </p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <span>StealthRL</span>
+      <span>Adversarial evaluation for AI-text detectors</span>
+      <span><a href="https://github.com/suraj-ranganath/StealthRL" target="_blank" rel="noreferrer">GitHub</a></span>
+    </footer>
+
+    <script src="/static/app.js" type="module"></script>
+  </body>
+</html>

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -151,9 +151,17 @@
         </details>
 
         <div class="feedback-row" id="feedbackRow" hidden>
-          <span>Was this rewrite useful?</span>
-          <button type="button" data-feedback-rating="up" aria-label="Thumbs up">Thumbs up</button>
-          <button type="button" data-feedback-rating="down" aria-label="Thumbs down">Thumbs down</button>
+          <span>Did it preserve meaning and read naturally?</span>
+          <button type="button" data-feedback-rating="up" aria-label="Good output" title="Good output">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M7 10v10H4V10h3Zm3 10h7.2c1.1 0 2-.8 2.2-1.9l1-5.5A2.2 2.2 0 0 0 18.2 10H15V6.8C15 5.3 13.9 4 12.4 4h-.5L10 9.2V20Z" />
+            </svg>
+          </button>
+          <button type="button" data-feedback-rating="down" aria-label="Poor output" title="Poor output">
+            <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+              <path d="M7 4v10H4V4h3Zm3 0h7.2c1.1 0 2 .8 2.2 1.9l1 5.5A2.2 2.2 0 0 1 18.2 14H15v3.2c0 1.5-1.1 2.8-2.6 2.8h-.5L10 14.8V4Z" />
+            </svg>
+          </button>
           <strong id="feedbackStatus" aria-live="polite"></strong>
         </div>
       </section>

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -113,18 +113,31 @@
           Your paraphrase will appear here after the request completes.
         </div>
 
-        <div class="detector-links" aria-label="External detector handoff">
-          <span>Copy output and open:</span>
-          <button type="button" data-detector-url="https://www.pangram.com/" disabled>Pangram</button>
-          <button type="button" data-detector-url="https://gptzero.me/" disabled>GPTZero</button>
-          <button type="button" data-detector-url="https://www.grammarly.com/ai-detector" disabled>Grammarly</button>
-        </div>
-
         <div class="metric-grid" id="metricGrid">
           <div><span>Input words</span><strong>-</strong></div>
           <div><span>Output words</span><strong>-</strong></div>
           <div><span>Edit rate</span><strong>-</strong></div>
           <div><span>Latency</span><strong>-</strong></div>
+        </div>
+
+        <div class="detector-links" aria-label="External detector handoff">
+          <span class="detector-links-label">Copy output and open:</span>
+          <button type="button" data-detector-name="Pangram" data-detector-url="https://www.pangram.com/" disabled>
+            <span class="detector-logo pangram-logo" aria-hidden="true">P</span>
+            <span>Pangram</span>
+          </button>
+          <button type="button" data-detector-name="GPTZero" data-detector-url="https://gptzero.me/" disabled>
+            <span class="detector-logo gptzero-logo" aria-hidden="true">G0</span>
+            <span>GPTZero</span>
+          </button>
+          <button type="button" data-detector-name="Grammarly" data-detector-url="https://www.grammarly.com/ai-detector" disabled>
+            <span class="detector-logo grammarly-logo" aria-hidden="true">G</span>
+            <span>Grammarly</span>
+          </button>
+          <button type="button" data-detector-name="TELL" data-detector-url="https://ai-tells.tech/" disabled>
+            <span class="detector-logo tell-logo" aria-hidden="true">T</span>
+            <span>TELL</span>
+          </button>
         </div>
 
         <details class="original-box">

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -28,10 +28,10 @@
         </div>
         <p class="subtitle">
           AI-text detectors are increasingly used in high-stakes settings, yet their robustness to
-          meaning-preserving adversarial rewriting remains uncertain. We introduce StealthRL, a
-          reinforcement learning framework for stress-testing AI-text detectors with adaptive
-          paraphrase attacks. StealthRL trains a paraphrase policy against a detector ensemble while
-          preserving semantic content, then evaluates transfer to held-out detector families.
+          meaning-preserving adversarial rewriting remains uncertain. StealthRL is an RL framework
+          for stress-testing AI-text detectors with adaptive paraphrase attacks. StealthRL trains a
+          paraphrase policy against a detector ensemble while preserving semantic content, then
+          evaluates transfer to held-out detector families.
         </p>
         <div class="disclaimer">
           <strong>Research preview.</strong>

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -69,18 +69,22 @@
           spellcheck="true"
         >During sustained cardio exercise, the heart increases its workload and the rest of the body adjusts to support that effort. Blood vessels widen to improve circulation, leg and core muscles help push blood back toward the heart, and the lungs breathe faster to bring in oxygen while clearing waste gases such as carbon dioxide throughout the workout and recovery period.</textarea>
 
-        <div class="settings-grid">
-          <label>
-            Temperature
-            <span id="temperatureValue">0.90</span>
-            <input id="temperature" name="temperature" type="range" min="0" max="1.5" value="0.9" step="0.05" />
-          </label>
-          <label>
-            Top-p
-            <span id="topPValue">0.95</span>
-            <input id="topP" name="top_p" type="range" min="0.1" max="1" value="0.95" step="0.05" />
-          </label>
-        </div>
+        <details class="config-box">
+          <summary>Generation config</summary>
+          <p>Defaults match the paper evaluation setting.</p>
+          <div class="settings-grid">
+            <label>
+              Temperature
+              <span id="temperatureValue">1.00</span>
+              <input id="temperature" name="temperature" type="range" min="0" max="1.5" value="1.0" step="0.05" />
+            </label>
+            <label>
+              Top-p
+              <span id="topPValue">0.90</span>
+              <input id="topP" name="top_p" type="range" min="0.1" max="1" value="0.9" step="0.05" />
+            </label>
+          </div>
+        </details>
 
         <details class="api-key-box">
           <summary>Use API key for extended access</summary>

--- a/demo/static/index.html
+++ b/demo/static/index.html
@@ -96,8 +96,6 @@
 
         <div class="action-row">
           <button class="primary-button" type="submit" id="submitButton">Run StealthRL</button>
-          <button class="secondary-button" type="button" id="sampleButton">Next sample</button>
-          <span class="pill muted" id="backendPill">backend: unknown</span>
         </div>
 
         <div class="progress-wrap" aria-hidden="true">
@@ -115,7 +113,6 @@
         </div>
 
         <div class="result-copy" id="outputText">
-          <div class="output-action-note" id="outputActionNote" hidden></div>
           <div id="outputBody">Your paraphrase will appear here after the request completes.</div>
         </div>
 
@@ -146,10 +143,19 @@
           </button>
         </div>
 
+        <div class="output-action-note" id="outputActionNote" hidden></div>
+
         <details class="original-box">
           <summary>Show original text</summary>
           <p id="originalText">Run the demo to compare source and rewritten text.</p>
         </details>
+
+        <div class="feedback-row" id="feedbackRow" hidden>
+          <span>Was this rewrite useful?</span>
+          <button type="button" data-feedback-rating="up" aria-label="Thumbs up">Thumbs up</button>
+          <button type="button" data-feedback-rating="down" aria-label="Thumbs down">Thumbs down</button>
+          <strong id="feedbackStatus" aria-live="polite"></strong>
+        </div>
       </section>
 
       <footer class="footer">

--- a/demo/static/privacy.html
+++ b/demo/static/privacy.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Privacy information · StealthRL Demo</title>
+    <meta
+      name="description"
+      content="Privacy information for the StealthRL research demo."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <div class="bg-grid" aria-hidden="true"></div>
+
+    <main class="wrap privacy-doc">
+      <header class="hero privacy-hero">
+        <p class="kicker"><a href="/">Back to demo</a></p>
+        <div class="title-row">
+          <span class="brand-mark">SRL</span>
+          <h1>Privacy information</h1>
+        </div>
+        <p class="subtitle">
+          This page explains what the StealthRL Demo processes when you submit text to the
+          research preview.
+        </p>
+      </header>
+
+      <section class="panel privacy-panel" aria-label="Privacy information">
+        <h2>Who runs this demo</h2>
+        <p>
+          The StealthRL Demo is operated by Suraj Ranganath and Atharv Ramesh for research
+          demonstration and evaluation purposes.
+        </p>
+
+        <h2>What data is processed</h2>
+        <ul>
+          <li>
+            <strong>Submitted text.</strong> The text you paste is sent to the demo backend so a
+            paraphrase can be generated and returned to your browser.
+          </li>
+          <li>
+            <strong>Generated output.</strong> The paraphrased output and lightweight text-shape
+            metrics are produced for the current request.
+          </li>
+          <li>
+            <strong>Quota metadata.</strong> The service stores daily usage counters in SQLite.
+            Public quota subjects and API-key subjects are hashed before storage.
+          </li>
+          <li>
+            <strong>Connection metadata.</strong> Hosting, reverse proxy, tunnel, or server logs
+            may process technical metadata such as IP address, user agent, timestamp, and request
+            path.
+          </li>
+          <li>
+            <strong>Optional API key.</strong> If you enter an API key in the browser, the browser
+            stores it in local storage so you do not need to retype it. The server receives it only
+            with requests you submit.
+          </li>
+        </ul>
+
+        <h2>What is not intentionally stored</h2>
+        <p>
+          The demo application does not intentionally persist submitted source text, generated
+          paraphrases, or per-request model outputs in its quota database. Do not submit private,
+          sensitive, confidential, or regulated text, because request content may still pass through
+          infrastructure logs or external inference services depending on deployment.
+        </p>
+
+        <h2>External inference services</h2>
+        <p>
+          The public preview may run in a no-cost mock backend or in a real StealthRL inference
+          backend. If a deployment is configured to call Tinker or another model service, the text
+          you submit is transmitted to that service for generation under that provider's terms and
+          privacy practices.
+        </p>
+
+        <h2>How the data is used</h2>
+        <ul>
+          <li>To return a paraphrased output for the text you submit.</li>
+          <li>To enforce the public daily quota and any API-key quota.</li>
+          <li>To monitor, debug, secure, and improve the research demo.</li>
+        </ul>
+
+        <h2>Retention</h2>
+        <p>
+          Quota counters are tracked by day and may remain in the configured SQLite usage database
+          until the operator deletes or rotates that database. Browser local storage remains on your
+          device until you clear it. Infrastructure logs, if present, follow the retention policies
+          of the deployment environment.
+        </p>
+
+        <h2>Your choices</h2>
+        <ul>
+          <li>Do not use the demo for sensitive or private text.</li>
+          <li>Clear your browser storage if you want to remove a saved API key.</li>
+          <li>Use an API key only if one has been issued to you by the operators.</li>
+        </ul>
+
+        <h2>Contact</h2>
+        <p>
+          For privacy or demo-operation questions, contact the project maintainers through the
+          public project links on the demo page.
+        </p>
+
+        <h2>Changes</h2>
+        <p>
+          This page may be updated as the demo deployment changes. The version shown here applies
+          to your current visit.
+        </p>
+      </section>
+
+      <footer class="footer">
+        <span>
+          <a href="https://www.linkedin.com/in/suraj-ranganath/" target="_blank" rel="noreferrer">Suraj Ranganath</a>
+          &amp;
+          <a href="https://www.linkedin.com/in/atharv-ramesh/" target="_blank" rel="noreferrer">Atharv Ramesh</a>
+        </span>
+        <span><a href="/privacy">Privacy</a></span>
+        <span>Copyright &copy; 2026. All rights reserved.</span>
+      </footer>
+    </main>
+  </body>
+</html>

--- a/demo/static/privacy.html
+++ b/demo/static/privacy.html
@@ -54,6 +54,11 @@
             Public quota subjects and API-key subjects are hashed before storage.
           </li>
           <li>
+            <strong>Optional feedback.</strong> If you click thumbs up or thumbs down, the service
+            stores the request identifier, rating, hashed client identifier, optional API-key label,
+            and timestamp.
+          </li>
+          <li>
             <strong>Connection metadata.</strong> Hosting, reverse proxy, tunnel, or server logs
             may process technical metadata such as IP address, user agent, timestamp, and request
             path.
@@ -68,9 +73,10 @@
         <h2>What is not intentionally stored</h2>
         <p>
           The demo application does not intentionally persist submitted source text, generated
-          paraphrases, or per-request model outputs in its quota database. Do not submit private,
-          sensitive, confidential, or regulated text, because request content may still pass through
-          infrastructure logs or external inference services depending on deployment.
+          paraphrases, or per-request model outputs in its quota and feedback database. Do not
+          submit private, sensitive, confidential, or regulated text, because request content may
+          still pass through infrastructure logs or external inference services depending on
+          deployment.
         </p>
 
         <h2>External inference services</h2>
@@ -85,15 +91,16 @@
         <ul>
           <li>To return a paraphrased output for the text you submit.</li>
           <li>To enforce the public daily quota and any API-key quota.</li>
+          <li>To understand whether demo outputs are useful through optional thumbs feedback.</li>
           <li>To monitor, debug, secure, and improve the research demo.</li>
         </ul>
 
         <h2>Retention</h2>
         <p>
-          Quota counters are tracked by day and may remain in the configured SQLite usage database
-          until the operator deletes or rotates that database. Browser local storage remains on your
-          device until you clear it. Infrastructure logs, if present, follow the retention policies
-          of the deployment environment.
+          Quota counters and optional feedback events may remain in the configured SQLite usage
+          database until the operator deletes or rotates that database. Browser local storage remains
+          on your device until you clear it. Infrastructure logs, if present, follow the retention
+          policies of the deployment environment.
         </p>
 
         <h2>Your choices</h2>

--- a/demo/static/styles.css
+++ b/demo/static/styles.css
@@ -452,6 +452,51 @@ summary {
   font-size: 0.78rem;
 }
 
+.footer a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.footer a:hover {
+  color: var(--accent-2);
+  text-decoration: underline;
+}
+
+.privacy-hero h1 {
+  font-size: clamp(2.9rem, 8vw, 5.8rem);
+}
+
+.privacy-panel {
+  line-height: 1.58;
+}
+
+.privacy-panel h2 {
+  margin: 1.4rem 0 0.45rem;
+  color: var(--ink);
+  font-size: 1.12rem;
+  line-height: 1.15;
+  letter-spacing: -0.015em;
+}
+
+.privacy-panel h2:first-child {
+  margin-top: 0;
+}
+
+.privacy-panel p {
+  margin: 0 0 0.75rem;
+  color: var(--muted);
+}
+
+.privacy-panel ul {
+  margin: 0.35rem 0 0.85rem;
+  padding-left: 1.25rem;
+  color: var(--muted);
+}
+
+.privacy-panel li {
+  margin-bottom: 0.45rem;
+}
+
 [hidden] {
   display: none !important;
 }

--- a/demo/static/styles.css
+++ b/demo/static/styles.css
@@ -1,17 +1,18 @@
 :root {
-  --ink: #13231d;
-  --ink-soft: #3d5148;
-  --paper: #f6f0df;
-  --paper-deep: #eadfbe;
-  --moss: #184236;
-  --moss-2: #245c49;
-  --mint: #9fd3b6;
-  --amber: #d69b36;
-  --clay: #b7643f;
-  --line: rgba(19, 35, 29, 0.16);
-  --shadow: 0 24px 70px rgba(26, 43, 35, 0.18);
-  --radius-lg: 32px;
-  --radius-md: 20px;
+  --paper: #f3efe2;
+  --panel: #fffaf0;
+  --panel-2: #f7f0dc;
+  --ink: #151c19;
+  --muted: #59665f;
+  --faint: #849189;
+  --line: #cabf9e;
+  --line-strong: #8b8064;
+  --accent: #0c5b4a;
+  --accent-2: #b85f2c;
+  --accent-3: #d6a532;
+  --danger: #a93c2e;
+  --success: #1f6b43;
+  --shadow: 8px 8px 0 rgba(21, 28, 25, 0.1);
 }
 
 * {
@@ -27,512 +28,459 @@ body {
   min-height: 100vh;
   color: var(--ink);
   background:
-    radial-gradient(circle at 10% 0%, rgba(214, 155, 54, 0.28), transparent 28rem),
-    radial-gradient(circle at 92% 14%, rgba(159, 211, 182, 0.38), transparent 30rem),
-    linear-gradient(135deg, #f9f2df 0%, #eee1c3 48%, #f4ecd6 100%);
-  font-family: "Space Grotesk", sans-serif;
-  overflow-x: hidden;
+    radial-gradient(circle at 85% 8%, rgba(214, 165, 50, 0.22), transparent 22rem),
+    radial-gradient(circle at 9% 24%, rgba(12, 91, 74, 0.14), transparent 24rem),
+    var(--paper);
+  font-family: "IBM Plex Sans", sans-serif;
 }
 
 a {
   color: inherit;
 }
 
-.grain {
+.bg-grid {
   position: fixed;
   inset: 0;
-  pointer-events: none;
-  opacity: 0.22;
   z-index: -1;
+  pointer-events: none;
   background-image:
-    linear-gradient(rgba(19, 35, 29, 0.045) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(19, 35, 29, 0.04) 1px, transparent 1px);
-  background-size: 38px 38px;
-  mask-image: linear-gradient(to bottom, black, transparent 82%);
+    linear-gradient(rgba(21, 28, 25, 0.075) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(21, 28, 25, 0.075) 1px, transparent 1px);
+  background-size: 28px 28px;
+  mask-image: linear-gradient(to bottom, black 0%, black 62%, transparent 100%);
 }
 
-.orb {
-  position: fixed;
-  border-radius: 999px;
-  filter: blur(8px);
-  opacity: 0.5;
-  z-index: -2;
-}
-
-.orb-a {
-  width: 24rem;
-  height: 24rem;
-  right: -8rem;
-  top: 18rem;
-  background: rgba(183, 100, 63, 0.28);
-}
-
-.orb-b {
-  width: 18rem;
-  height: 18rem;
-  left: -6rem;
-  bottom: 10rem;
-  background: rgba(36, 92, 73, 0.22);
-}
-
-.nav {
-  width: min(1180px, calc(100% - 32px));
-  margin: 18px auto 0;
-  padding: 14px 18px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 18px;
-  background: rgba(246, 240, 223, 0.72);
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  box-shadow: 0 12px 40px rgba(19, 35, 29, 0.08);
-  backdrop-filter: blur(18px);
-}
-
-.brand,
-.nav-links {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.brand {
-  text-decoration: none;
-  font-weight: 700;
-}
-
-.brand-mark {
-  display: grid;
-  width: 38px;
-  height: 38px;
-  place-items: center;
-  color: #fff9e8;
-  background: var(--moss);
-  border-radius: 50%;
-  font-size: 0.75rem;
-  letter-spacing: 0.08em;
-}
-
-.nav-links a {
-  padding: 8px 10px;
-  color: var(--ink-soft);
-  text-decoration: none;
-  font-size: 0.92rem;
-}
-
-.nav-links a:hover {
-  color: var(--ink);
-}
-
-main {
-  width: min(1180px, calc(100% - 32px));
+.wrap {
+  width: min(980px, calc(100% - 28px));
   margin: 0 auto;
+  padding: 42px 0 34px;
 }
 
 .hero {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 390px;
-  gap: 42px;
-  align-items: center;
-  padding: 86px 0 46px;
+  margin-bottom: 22px;
 }
 
-.eyebrow {
-  margin: 0 0 14px;
-  color: var(--clay);
+.kicker,
+.section-label {
+  margin: 0 0 8px;
+  color: var(--accent-2);
+  font-family: "IBM Plex Mono", monospace;
   font-size: 0.78rem;
-  font-weight: 700;
-  letter-spacing: 0.16em;
+  font-weight: 600;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
-h1,
-h2,
-h3 {
-  margin: 0;
-  line-height: 0.96;
-  letter-spacing: -0.055em;
+.title-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+
+.brand-mark {
+  display: inline-grid;
+  width: 54px;
+  height: 54px;
+  place-items: center;
+  color: #fff7e3;
+  background: var(--accent);
+  border: 2px solid var(--ink);
+  box-shadow: 4px 4px 0 var(--ink);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
 }
 
 h1,
 h2 {
-  font-family: "Fraunces", serif;
+  margin: 0;
+  letter-spacing: -0.04em;
 }
 
 h1 {
-  max-width: 780px;
-  font-size: clamp(4rem, 9vw, 8.6rem);
+  font-size: clamp(3.2rem, 10vw, 6.9rem);
+  line-height: 0.9;
 }
 
 h2 {
-  font-size: clamp(2rem, 4vw, 4.6rem);
-}
-
-h3 {
-  font-size: 1.05rem;
-  letter-spacing: -0.02em;
-}
-
-.lede {
-  max-width: 690px;
-  margin: 26px 0 0;
-  color: var(--ink-soft);
-  font-size: clamp(1.05rem, 2vw, 1.24rem);
-  line-height: 1.65;
-}
-
-.hero-actions,
-.form-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px;
-  margin-top: 28px;
-}
-
-.button {
-  border: 0;
-  border-radius: 999px;
-  padding: 13px 19px;
-  font: inherit;
-  font-weight: 700;
-  text-decoration: none;
-  cursor: pointer;
-  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
-}
-
-.button:hover {
-  transform: translateY(-1px);
-}
-
-.button.primary {
-  color: #fff9e8;
-  background: var(--moss);
-  box-shadow: 0 14px 28px rgba(24, 66, 54, 0.22);
-}
-
-.button.primary:disabled {
-  cursor: wait;
-  opacity: 0.7;
-}
-
-.button.ghost {
-  color: var(--ink);
-  background: rgba(255, 250, 235, 0.6);
-  border: 1px solid var(--line);
-}
-
-.hero-card,
-.panel,
-.method-grid article {
-  background: rgba(255, 250, 235, 0.72);
-  border: 1px solid var(--line);
-  box-shadow: var(--shadow);
-  backdrop-filter: blur(18px);
-}
-
-.hero-card {
-  padding: 28px;
-  border-radius: var(--radius-lg);
-}
-
-.metric-ring {
-  display: grid;
-  width: 230px;
-  height: 230px;
-  margin: 0 auto 24px;
-  place-items: center;
-  text-align: center;
-  border-radius: 50%;
-  background:
-    radial-gradient(circle at center, rgba(255, 250, 235, 0.95) 0 55%, transparent 56%),
-    conic-gradient(var(--moss) 0 351deg, rgba(19, 35, 29, 0.12) 351deg 360deg);
-}
-
-.metric-value {
-  display: block;
-  font-family: "Fraunces", serif;
-  font-size: 3rem;
+  font-size: clamp(1.42rem, 3.2vw, 2.35rem);
   line-height: 1;
 }
 
-.metric-label {
-  display: block;
-  max-width: 135px;
-  margin-top: -56px;
-  color: var(--ink-soft);
-  font-size: 0.9rem;
+.subtitle {
+  max-width: 780px;
+  margin: 18px 0 0;
+  color: var(--muted);
+  font-size: clamp(1rem, 1.8vw, 1.18rem);
+  line-height: 1.55;
 }
 
-.metric-list {
-  display: grid;
-  gap: 10px;
+.disclaimer {
+  max-width: 820px;
+  margin-top: 18px;
+  padding: 13px 15px;
+  color: #31271f;
+  background: #fff2c6;
+  border: 1px solid #c59639;
+  font-size: 0.94rem;
+  line-height: 1.45;
 }
 
-.metric-list div,
-.metric-grid div {
+.link-row {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 14px;
-  padding: 12px 0;
-  border-top: 1px solid var(--line);
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 18px;
 }
 
-.metric-list span,
-.metric-grid span {
-  color: var(--ink-soft);
+.link-row a,
+.sample-option,
+.secondary-button {
+  border: 1px solid var(--line-strong);
+  color: var(--ink);
+  background: rgba(255, 250, 240, 0.82);
+  font: inherit;
+  font-size: 0.92rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
 }
 
-.demo-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.02fr) minmax(340px, 0.98fr);
-  gap: 22px;
-  align-items: start;
-  padding: 30px 0 70px;
+.link-row a {
+  padding: 7px 10px;
+}
+
+.link-row a:hover,
+.sample-option:hover,
+.secondary-button:hover {
+  background: #f2dba0;
 }
 
 .panel {
-  border-radius: var(--radius-lg);
-  padding: 24px;
+  margin-top: 16px;
+  padding: clamp(18px, 3vw, 26px);
+  background: rgba(255, 250, 240, 0.94);
+  border: 2px solid var(--ink);
+  box-shadow: var(--shadow);
 }
 
-.panel-heading {
+.panel-head {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 16px;
+  gap: 18px;
   margin-bottom: 18px;
 }
 
-.quota-pill,
-.backend-pill {
-  white-space: nowrap;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  padding: 8px 10px;
-  color: var(--ink-soft);
-  background: rgba(246, 240, 223, 0.7);
+.pill {
+  display: inline-flex;
+  align-items: center;
+  min-height: 30px;
+  padding: 5px 9px;
+  color: #fff7e3;
+  background: var(--accent);
+  border: 1px solid var(--ink);
+  font-family: "IBM Plex Mono", monospace;
   font-size: 0.78rem;
-  font-weight: 700;
+  font-weight: 500;
+  white-space: nowrap;
+}
+
+.pill.muted {
+  color: var(--ink);
+  background: var(--panel-2);
+}
+
+.sample-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-bottom: 14px;
+}
+
+.sample-option {
+  padding: 8px 10px;
+}
+
+.sample-option[aria-pressed="true"] {
+  color: #fff7e3;
+  background: var(--accent-2);
 }
 
 .field {
-  display: grid;
-  gap: 8px;
-  color: var(--ink-soft);
-  font-weight: 700;
+  display: block;
+  margin-bottom: 8px;
+  color: var(--muted);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.82rem;
+  font-weight: 600;
+  text-transform: uppercase;
 }
 
 textarea,
 input[type="password"] {
   width: 100%;
   color: var(--ink);
-  background: rgba(255, 252, 242, 0.9);
-  border: 1px solid rgba(19, 35, 29, 0.22);
-  border-radius: var(--radius-md);
+  background: #fffdf6;
+  border: 1px solid var(--line-strong);
+  border-radius: 0;
   font: inherit;
-  outline: none;
 }
 
 textarea {
-  min-height: 280px;
-  padding: 18px;
+  min-height: 230px;
+  padding: 14px;
   line-height: 1.55;
   resize: vertical;
 }
 
-input[type="password"] {
-  padding: 12px 14px;
-}
-
 textarea:focus,
-input:focus {
-  border-color: var(--moss);
-  box-shadow: 0 0 0 4px rgba(36, 92, 73, 0.12);
+input[type="password"]:focus {
+  outline: 3px solid rgba(214, 165, 50, 0.45);
+  outline-offset: 1px;
 }
 
-.controls {
+.settings-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 14px;
-  margin-top: 18px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 14px 0;
 }
 
-.controls label {
+.settings-grid label {
   display: grid;
   grid-template-columns: 1fr auto;
   gap: 8px 12px;
   align-items: center;
-  padding: 14px;
+  padding: 12px;
+  background: var(--panel-2);
   border: 1px solid var(--line);
-  border-radius: var(--radius-md);
-  color: var(--ink-soft);
-  font-weight: 700;
-  background: rgba(246, 240, 223, 0.54);
+  color: var(--muted);
+  font-size: 0.9rem;
+  font-weight: 600;
 }
 
-.controls input {
+.settings-grid span {
+  color: var(--accent-2);
+  font-family: "IBM Plex Mono", monospace;
+}
+
+input[type="range"] {
   grid-column: 1 / -1;
-  accent-color: var(--moss);
+  width: 100%;
+  accent-color: var(--accent);
 }
 
-.api-key-box {
-  margin-top: 16px;
-  padding: 14px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius-md);
-  background: rgba(246, 240, 223, 0.54);
+.api-key-box,
+.original-box {
+  margin-top: 12px;
+  padding: 12px;
+  background: rgba(247, 240, 220, 0.74);
+  border: 1px dashed var(--line-strong);
 }
 
-.api-key-box summary {
+summary {
   cursor: pointer;
   font-weight: 700;
 }
 
+.api-key-box input {
+  margin-top: 6px;
+  padding: 10px 12px;
+}
+
 .api-key-box p,
-.fine-print {
-  color: var(--ink-soft);
-  font-size: 0.9rem;
+.original-box p {
+  margin: 10px 0 0;
+  color: var(--muted);
   line-height: 1.5;
 }
 
-.compact {
+.field.compact {
   margin-top: 12px;
 }
 
-.status-line {
-  min-height: 26px;
-  color: var(--clay);
-  font-weight: 700;
-}
-
-.result-card,
-.compare-box {
+.action-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
   margin-top: 16px;
-  padding: 18px;
-  border-radius: var(--radius-md);
-  background: #fffaf0;
-  border: 1px solid var(--line);
 }
 
-.result-card p,
-.compare-box p {
-  margin: 12px 0 0;
-  line-height: 1.65;
+.primary-button,
+.secondary-button {
+  min-height: 42px;
+  padding: 10px 14px;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
 }
 
-.placeholder,
-.muted-copy {
-  color: var(--ink-soft);
+.primary-button {
+  color: #fff7e3;
+  background: var(--accent);
+  border: 2px solid var(--ink);
+  box-shadow: 4px 4px 0 var(--ink);
+}
+
+.primary-button:hover {
+  transform: translate(-1px, -1px);
+  box-shadow: 5px 5px 0 var(--ink);
+}
+
+.primary-button:disabled {
+  cursor: wait;
+  opacity: 0.72;
+  transform: none;
+  box-shadow: 4px 4px 0 var(--ink);
+}
+
+.secondary-button {
+  padding-inline: 12px;
+}
+
+.progress-wrap {
+  height: 8px;
+  margin-top: 16px;
+  overflow: hidden;
+  background: #e8dcc1;
+  border: 1px solid var(--line-strong);
+}
+
+.progress-bar {
+  width: 0%;
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-3), var(--accent-2));
+  transition: width 220ms ease;
+}
+
+.progress-bar.is-running {
+  width: 100%;
+  animation: progressSweep 1.25s ease-in-out infinite;
+}
+
+@keyframes progressSweep {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.status-line {
+  min-height: 1.4em;
+  margin: 10px 0 0;
+  color: var(--muted);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.86rem;
+}
+
+.status-line[data-tone="busy"] {
+  color: var(--accent-2);
+}
+
+.status-line[data-tone="done"] {
+  color: var(--success);
+}
+
+.status-line[data-tone="error"] {
+  color: var(--danger);
+}
+
+.result-panel {
+  margin-bottom: 20px;
+}
+
+.result-copy {
+  min-height: 150px;
+  padding: 14px;
+  background: #fffdf6;
+  border: 1px solid var(--line-strong);
+  color: var(--ink);
+  font-size: 1rem;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.result-copy.placeholder {
+  color: var(--faint);
 }
 
 .metric-grid {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0 16px;
-  margin-top: 18px;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 12px;
 }
 
-.section-heading {
-  max-width: 800px;
-  margin-bottom: 22px;
+.metric-grid div {
+  min-height: 70px;
+  padding: 10px;
+  background: var(--panel-2);
+  border: 1px solid var(--line);
 }
 
-.method {
-  padding: 26px 0 82px;
+.metric-grid span {
+  display: block;
+  color: var(--muted);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
 }
 
-.method-grid {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 18px;
-}
-
-.method-grid article {
-  padding: 22px;
-  border-radius: var(--radius-lg);
-}
-
-.step {
-  display: inline-grid;
-  width: 42px;
-  height: 42px;
-  place-items: center;
-  margin-bottom: 28px;
-  color: #fff9e8;
-  background: var(--moss);
-  border-radius: 50%;
-  font-weight: 800;
-}
-
-.method-grid p {
-  color: var(--ink-soft);
-  line-height: 1.62;
+.metric-grid strong {
+  display: block;
+  margin-top: 8px;
+  color: var(--ink);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 1rem;
 }
 
 .footer {
-  width: min(1180px, calc(100% - 32px));
-  margin: 0 auto 28px;
-  padding: 18px 0;
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
-  gap: 18px;
-  color: var(--ink-soft);
-  border-top: 1px solid var(--line);
+  gap: 12px;
+  margin-top: 24px;
+  color: var(--muted);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.78rem;
 }
 
-@media (max-width: 920px) {
-  .hero,
-  .demo-grid,
-  .method-grid {
-    grid-template-columns: 1fr;
+[hidden] {
+  display: none !important;
+}
+
+@media (max-width: 720px) {
+  .wrap {
+    width: min(100% - 20px, 980px);
+    padding-top: 24px;
   }
 
-  .hero {
-    padding-top: 56px;
-  }
-
-  .hero-card {
-    max-width: 480px;
-  }
-
-  .nav {
+  .title-row,
+  .panel-head {
     align-items: flex-start;
-    border-radius: 26px;
   }
 
-  .nav-links {
-    display: none;
-  }
-}
-
-@media (max-width: 620px) {
-  main,
-  .nav,
-  .footer {
-    width: min(100% - 20px, 1180px);
-  }
-
-  h1 {
-    font-size: 3.25rem;
-  }
-
-  .panel {
-    padding: 18px;
-  }
-
-  .panel-heading,
-  .footer {
+  .title-row {
     flex-direction: column;
+    gap: 10px;
   }
 
-  .controls,
+  .settings-grid,
   .metric-grid {
     grid-template-columns: 1fr;
   }
 
+  .pill {
+    white-space: normal;
+  }
+
   textarea {
-    min-height: 230px;
+    min-height: 260px;
   }
 }

--- a/demo/static/styles.css
+++ b/demo/static/styles.css
@@ -409,8 +409,11 @@ summary {
 }
 
 .result-copy {
+  display: flex;
+  align-items: flex-start;
+  justify-content: flex-start;
   min-height: 150px;
-  padding: 14px;
+  padding: 12px 14px;
   background: #fffdf6;
   border: 1px solid var(--line-strong);
   color: var(--ink);
@@ -427,7 +430,10 @@ summary {
 
 #outputBody {
   display: block;
-  min-height: 118px;
+  width: 100%;
+  min-height: 0;
+  margin: 0;
+  padding: 0;
 }
 
 .output-action-note {

--- a/demo/static/styles.css
+++ b/demo/static/styles.css
@@ -416,15 +416,22 @@ summary {
   color: var(--ink);
   font-size: 1rem;
   line-height: 1.6;
+  text-align: left;
   white-space: pre-wrap;
+  overflow-wrap: anywhere;
 }
 
 .result-copy.placeholder {
   color: var(--faint);
 }
 
+#outputBody {
+  display: block;
+  min-height: 118px;
+}
+
 .output-action-note {
-  margin-bottom: 10px;
+  margin-top: 10px;
   padding: 8px 10px;
   color: var(--success);
   background: rgba(31, 107, 67, 0.09);
@@ -439,6 +446,12 @@ summary {
   color: var(--danger);
   background: rgba(169, 60, 46, 0.09);
   border-color: rgba(169, 60, 46, 0.4);
+}
+
+.output-action-note[data-tone="neutral"] {
+  color: var(--accent-2);
+  background: rgba(214, 165, 50, 0.12);
+  border-color: rgba(184, 95, 44, 0.36);
 }
 
 .detector-links {
@@ -539,6 +552,47 @@ summary {
   color: var(--ink);
   font-family: "IBM Plex Mono", monospace;
   font-size: 1rem;
+}
+
+.feedback-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.78rem;
+}
+
+.feedback-row button {
+  min-height: 34px;
+  padding: 6px 10px;
+  color: var(--ink);
+  background: #fffdf6;
+  border: 1px solid var(--line-strong);
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.feedback-row button:hover:not(:disabled),
+.feedback-row button[aria-pressed="true"] {
+  color: #fff7e3;
+  background: var(--accent);
+}
+
+.feedback-row button:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.feedback-row strong {
+  min-width: 72px;
+  color: var(--success);
+  font-weight: 600;
 }
 
 .footer {

--- a/demo/static/styles.css
+++ b/demo/static/styles.css
@@ -410,6 +410,24 @@ summary {
   color: var(--faint);
 }
 
+.output-action-note {
+  margin-bottom: 10px;
+  padding: 8px 10px;
+  color: var(--success);
+  background: rgba(31, 107, 67, 0.09);
+  border: 1px solid rgba(31, 107, 67, 0.4);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.35;
+}
+
+.output-action-note[data-tone="error"] {
+  color: var(--danger);
+  background: rgba(169, 60, 46, 0.09);
+  border-color: rgba(169, 60, 46, 0.4);
+}
+
 .detector-links {
   display: flex;
   flex-wrap: wrap;

--- a/demo/static/styles.css
+++ b/demo/static/styles.css
@@ -246,7 +246,7 @@ input[type="password"]:focus {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
-  margin: 14px 0;
+  margin: 10px 0 0;
 }
 
 .settings-grid label {
@@ -274,11 +274,18 @@ input[type="range"] {
 }
 
 .api-key-box,
+.config-box,
 .original-box {
   margin-top: 12px;
   padding: 12px;
   background: rgba(247, 240, 220, 0.74);
   border: 1px dashed var(--line-strong);
+}
+
+.config-box {
+  color: var(--muted);
+  background: rgba(247, 240, 220, 0.46);
+  border-color: rgba(139, 128, 100, 0.6);
 }
 
 summary {
@@ -292,10 +299,16 @@ summary {
 }
 
 .api-key-box p,
+.config-box p,
 .original-box p {
   margin: 10px 0 0;
   color: var(--muted);
   line-height: 1.5;
+}
+
+.config-box p {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.76rem;
 }
 
 .field.compact {

--- a/demo/static/styles.css
+++ b/demo/static/styles.css
@@ -109,7 +109,7 @@ h2 {
 }
 
 .subtitle {
-  max-width: 780px;
+  max-width: none;
   margin: 18px 0 0;
   color: var(--muted);
   font-size: clamp(1rem, 1.8vw, 1.18rem);

--- a/demo/static/styles.css
+++ b/demo/static/styles.css
@@ -410,6 +410,37 @@ summary {
   color: var(--faint);
 }
 
+.detector-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  color: var(--muted);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.78rem;
+}
+
+.detector-links button {
+  padding: 7px 9px;
+  color: var(--ink);
+  background: var(--panel-2);
+  border: 1px solid var(--line-strong);
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.detector-links button:hover:not(:disabled) {
+  color: #fff7e3;
+  background: var(--accent-2);
+}
+
+.detector-links button:disabled {
+  cursor: not-allowed;
+  opacity: 0.48;
+}
+
 .metric-grid {
   display: grid;
   grid-template-columns: repeat(4, minmax(0, 1fr));

--- a/demo/static/styles.css
+++ b/demo/static/styles.css
@@ -117,7 +117,7 @@ h2 {
 }
 
 .disclaimer {
-  max-width: 820px;
+  max-width: none;
   margin-top: 18px;
   padding: 13px 15px;
   color: #31271f;
@@ -125,6 +125,7 @@ h2 {
   border: 1px solid #c59639;
   font-size: 0.94rem;
   line-height: 1.45;
+  white-space: nowrap;
 }
 
 .link-row {
@@ -477,6 +478,10 @@ summary {
   }
 
   .pill {
+    white-space: normal;
+  }
+
+  .disclaimer {
     white-space: normal;
   }
 

--- a/demo/static/styles.css
+++ b/demo/static/styles.css
@@ -415,14 +415,22 @@ summary {
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;
-  margin-top: 12px;
+  margin-top: 14px;
   color: var(--muted);
   font-family: "IBM Plex Mono", monospace;
   font-size: 0.78rem;
 }
 
+.detector-links-label {
+  margin-right: 2px;
+}
+
 .detector-links button {
-  padding: 7px 9px;
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 36px;
+  padding: 6px 9px 6px 7px;
   color: var(--ink);
   background: var(--panel-2);
   border: 1px solid var(--line-strong);
@@ -439,6 +447,36 @@ summary {
 .detector-links button:disabled {
   cursor: not-allowed;
   opacity: 0.48;
+}
+
+.detector-logo {
+  display: inline-grid;
+  width: 22px;
+  height: 22px;
+  place-items: center;
+  color: #fff7e3;
+  border: 1px solid rgba(21, 28, 25, 0.34);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 0.63rem;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1;
+}
+
+.pangram-logo {
+  background: #d96b2c;
+}
+
+.gptzero-logo {
+  background: #1f6b43;
+}
+
+.grammarly-logo {
+  background: #027e6f;
+}
+
+.tell-logo {
+  background: #234b82;
 }
 
 .metric-grid {

--- a/demo/static/styles.css
+++ b/demo/static/styles.css
@@ -1,0 +1,538 @@
+:root {
+  --ink: #13231d;
+  --ink-soft: #3d5148;
+  --paper: #f6f0df;
+  --paper-deep: #eadfbe;
+  --moss: #184236;
+  --moss-2: #245c49;
+  --mint: #9fd3b6;
+  --amber: #d69b36;
+  --clay: #b7643f;
+  --line: rgba(19, 35, 29, 0.16);
+  --shadow: 0 24px 70px rgba(26, 43, 35, 0.18);
+  --radius-lg: 32px;
+  --radius-md: 20px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--ink);
+  background:
+    radial-gradient(circle at 10% 0%, rgba(214, 155, 54, 0.28), transparent 28rem),
+    radial-gradient(circle at 92% 14%, rgba(159, 211, 182, 0.38), transparent 30rem),
+    linear-gradient(135deg, #f9f2df 0%, #eee1c3 48%, #f4ecd6 100%);
+  font-family: "Space Grotesk", sans-serif;
+  overflow-x: hidden;
+}
+
+a {
+  color: inherit;
+}
+
+.grain {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.22;
+  z-index: -1;
+  background-image:
+    linear-gradient(rgba(19, 35, 29, 0.045) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(19, 35, 29, 0.04) 1px, transparent 1px);
+  background-size: 38px 38px;
+  mask-image: linear-gradient(to bottom, black, transparent 82%);
+}
+
+.orb {
+  position: fixed;
+  border-radius: 999px;
+  filter: blur(8px);
+  opacity: 0.5;
+  z-index: -2;
+}
+
+.orb-a {
+  width: 24rem;
+  height: 24rem;
+  right: -8rem;
+  top: 18rem;
+  background: rgba(183, 100, 63, 0.28);
+}
+
+.orb-b {
+  width: 18rem;
+  height: 18rem;
+  left: -6rem;
+  bottom: 10rem;
+  background: rgba(36, 92, 73, 0.22);
+}
+
+.nav {
+  width: min(1180px, calc(100% - 32px));
+  margin: 18px auto 0;
+  padding: 14px 18px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  background: rgba(246, 240, 223, 0.72);
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  box-shadow: 0 12px 40px rgba(19, 35, 29, 0.08);
+  backdrop-filter: blur(18px);
+}
+
+.brand,
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.brand {
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.brand-mark {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  place-items: center;
+  color: #fff9e8;
+  background: var(--moss);
+  border-radius: 50%;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+}
+
+.nav-links a {
+  padding: 8px 10px;
+  color: var(--ink-soft);
+  text-decoration: none;
+  font-size: 0.92rem;
+}
+
+.nav-links a:hover {
+  color: var(--ink);
+}
+
+main {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 390px;
+  gap: 42px;
+  align-items: center;
+  padding: 86px 0 46px;
+}
+
+.eyebrow {
+  margin: 0 0 14px;
+  color: var(--clay);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+  line-height: 0.96;
+  letter-spacing: -0.055em;
+}
+
+h1,
+h2 {
+  font-family: "Fraunces", serif;
+}
+
+h1 {
+  max-width: 780px;
+  font-size: clamp(4rem, 9vw, 8.6rem);
+}
+
+h2 {
+  font-size: clamp(2rem, 4vw, 4.6rem);
+}
+
+h3 {
+  font-size: 1.05rem;
+  letter-spacing: -0.02em;
+}
+
+.lede {
+  max-width: 690px;
+  margin: 26px 0 0;
+  color: var(--ink-soft);
+  font-size: clamp(1.05rem, 2vw, 1.24rem);
+  line-height: 1.65;
+}
+
+.hero-actions,
+.form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 28px;
+}
+
+.button {
+  border: 0;
+  border-radius: 999px;
+  padding: 13px 19px;
+  font: inherit;
+  font-weight: 700;
+  text-decoration: none;
+  cursor: pointer;
+  transition: transform 150ms ease, box-shadow 150ms ease, background 150ms ease;
+}
+
+.button:hover {
+  transform: translateY(-1px);
+}
+
+.button.primary {
+  color: #fff9e8;
+  background: var(--moss);
+  box-shadow: 0 14px 28px rgba(24, 66, 54, 0.22);
+}
+
+.button.primary:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.button.ghost {
+  color: var(--ink);
+  background: rgba(255, 250, 235, 0.6);
+  border: 1px solid var(--line);
+}
+
+.hero-card,
+.panel,
+.method-grid article {
+  background: rgba(255, 250, 235, 0.72);
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(18px);
+}
+
+.hero-card {
+  padding: 28px;
+  border-radius: var(--radius-lg);
+}
+
+.metric-ring {
+  display: grid;
+  width: 230px;
+  height: 230px;
+  margin: 0 auto 24px;
+  place-items: center;
+  text-align: center;
+  border-radius: 50%;
+  background:
+    radial-gradient(circle at center, rgba(255, 250, 235, 0.95) 0 55%, transparent 56%),
+    conic-gradient(var(--moss) 0 351deg, rgba(19, 35, 29, 0.12) 351deg 360deg);
+}
+
+.metric-value {
+  display: block;
+  font-family: "Fraunces", serif;
+  font-size: 3rem;
+  line-height: 1;
+}
+
+.metric-label {
+  display: block;
+  max-width: 135px;
+  margin-top: -56px;
+  color: var(--ink-soft);
+  font-size: 0.9rem;
+}
+
+.metric-list {
+  display: grid;
+  gap: 10px;
+}
+
+.metric-list div,
+.metric-grid div {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  padding: 12px 0;
+  border-top: 1px solid var(--line);
+}
+
+.metric-list span,
+.metric-grid span {
+  color: var(--ink-soft);
+}
+
+.demo-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.02fr) minmax(340px, 0.98fr);
+  gap: 22px;
+  align-items: start;
+  padding: 30px 0 70px;
+}
+
+.panel {
+  border-radius: var(--radius-lg);
+  padding: 24px;
+}
+
+.panel-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.quota-pill,
+.backend-pill {
+  white-space: nowrap;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 8px 10px;
+  color: var(--ink-soft);
+  background: rgba(246, 240, 223, 0.7);
+  font-size: 0.78rem;
+  font-weight: 700;
+}
+
+.field {
+  display: grid;
+  gap: 8px;
+  color: var(--ink-soft);
+  font-weight: 700;
+}
+
+textarea,
+input[type="password"] {
+  width: 100%;
+  color: var(--ink);
+  background: rgba(255, 252, 242, 0.9);
+  border: 1px solid rgba(19, 35, 29, 0.22);
+  border-radius: var(--radius-md);
+  font: inherit;
+  outline: none;
+}
+
+textarea {
+  min-height: 280px;
+  padding: 18px;
+  line-height: 1.55;
+  resize: vertical;
+}
+
+input[type="password"] {
+  padding: 12px 14px;
+}
+
+textarea:focus,
+input:focus {
+  border-color: var(--moss);
+  box-shadow: 0 0 0 4px rgba(36, 92, 73, 0.12);
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  margin-top: 18px;
+}
+
+.controls label {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 8px 12px;
+  align-items: center;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  color: var(--ink-soft);
+  font-weight: 700;
+  background: rgba(246, 240, 223, 0.54);
+}
+
+.controls input {
+  grid-column: 1 / -1;
+  accent-color: var(--moss);
+}
+
+.api-key-box {
+  margin-top: 16px;
+  padding: 14px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: rgba(246, 240, 223, 0.54);
+}
+
+.api-key-box summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.api-key-box p,
+.fine-print {
+  color: var(--ink-soft);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.compact {
+  margin-top: 12px;
+}
+
+.status-line {
+  min-height: 26px;
+  color: var(--clay);
+  font-weight: 700;
+}
+
+.result-card,
+.compare-box {
+  margin-top: 16px;
+  padding: 18px;
+  border-radius: var(--radius-md);
+  background: #fffaf0;
+  border: 1px solid var(--line);
+}
+
+.result-card p,
+.compare-box p {
+  margin: 12px 0 0;
+  line-height: 1.65;
+}
+
+.placeholder,
+.muted-copy {
+  color: var(--ink-soft);
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0 16px;
+  margin-top: 18px;
+}
+
+.section-heading {
+  max-width: 800px;
+  margin-bottom: 22px;
+}
+
+.method {
+  padding: 26px 0 82px;
+}
+
+.method-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 18px;
+}
+
+.method-grid article {
+  padding: 22px;
+  border-radius: var(--radius-lg);
+}
+
+.step {
+  display: inline-grid;
+  width: 42px;
+  height: 42px;
+  place-items: center;
+  margin-bottom: 28px;
+  color: #fff9e8;
+  background: var(--moss);
+  border-radius: 50%;
+  font-weight: 800;
+}
+
+.method-grid p {
+  color: var(--ink-soft);
+  line-height: 1.62;
+}
+
+.footer {
+  width: min(1180px, calc(100% - 32px));
+  margin: 0 auto 28px;
+  padding: 18px 0;
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  color: var(--ink-soft);
+  border-top: 1px solid var(--line);
+}
+
+@media (max-width: 920px) {
+  .hero,
+  .demo-grid,
+  .method-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    padding-top: 56px;
+  }
+
+  .hero-card {
+    max-width: 480px;
+  }
+
+  .nav {
+    align-items: flex-start;
+    border-radius: 26px;
+  }
+
+  .nav-links {
+    display: none;
+  }
+}
+
+@media (max-width: 620px) {
+  main,
+  .nav,
+  .footer {
+    width: min(100% - 20px, 1180px);
+  }
+
+  h1 {
+    font-size: 3.25rem;
+  }
+
+  .panel {
+    padding: 18px;
+  }
+
+  .panel-heading,
+  .footer {
+    flex-direction: column;
+  }
+
+  .controls,
+  .metric-grid {
+    grid-template-columns: 1fr;
+  }
+
+  textarea {
+    min-height: 230px;
+  }
+}

--- a/demo/static/styles.css
+++ b/demo/static/styles.css
@@ -574,14 +574,23 @@ summary {
 }
 
 .feedback-row button {
+  display: inline-grid;
+  width: 38px;
   min-height: 34px;
-  padding: 6px 10px;
+  place-items: center;
+  padding: 6px;
   color: var(--ink);
   background: #fffdf6;
   border: 1px solid var(--line-strong);
   font: inherit;
   font-weight: 700;
   cursor: pointer;
+}
+
+.feedback-row svg {
+  width: 18px;
+  height: 18px;
+  fill: currentColor;
 }
 
 .feedback-row button:hover:not(:disabled),

--- a/demo/stealthrl_demo/__init__.py
+++ b/demo/stealthrl_demo/__init__.py
@@ -1,0 +1,5 @@
+"""FastAPI demo for StealthRL."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"

--- a/demo/stealthrl_demo/app.py
+++ b/demo/stealthrl_demo/app.py
@@ -22,8 +22,8 @@ STATIC_DIR = Path(__file__).resolve().parents[1] / "static"
 
 class ParaphraseRequest(BaseModel):
     text: str = Field(min_length=20)
-    temperature: float = Field(default=0.9, ge=0.0, le=1.5)
-    top_p: float = Field(default=0.95, ge=0.1, le=1.0)
+    temperature: float = Field(default=1.0, ge=0.0, le=1.5)
+    top_p: float = Field(default=0.9, ge=0.1, le=1.0)
 
 
 def _extract_api_key(request: Request) -> str | None:

--- a/demo/stealthrl_demo/app.py
+++ b/demo/stealthrl_demo/app.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, HTTPException, Request
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
@@ -77,6 +78,14 @@ def create_app(
     app.state.settings = settings
     app.state.quota_store = quota_store
     app.state.backend = backend
+
+    if settings.cors_origins:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=list(settings.cors_origins),
+            allow_methods=["GET", "POST", "OPTIONS"],
+            allow_headers=["authorization", "content-type", "x-stealthrl-api-key"],
+        )
 
     app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
 

--- a/demo/stealthrl_demo/app.py
+++ b/demo/stealthrl_demo/app.py
@@ -2,18 +2,22 @@
 
 from __future__ import annotations
 
+import asyncio
+import json
 import logging
+import time
+import uuid
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
 
 from .config import DemoSettings, load_settings
-from .inference import BaseDemoBackend, build_backend, run_paraphrase
+from .inference import BaseDemoBackend, build_backend, compute_metrics, run_paraphrase
 from .rate_limit import QuotaDecision, QuotaStore
 
 logger = logging.getLogger(__name__)
@@ -25,6 +29,11 @@ class ParaphraseRequest(BaseModel):
     text: str = Field(min_length=20)
     temperature: float = Field(default=1.0, ge=0.0, le=1.5)
     top_p: float = Field(default=0.9, ge=0.1, le=1.0)
+
+
+class FeedbackRequest(BaseModel):
+    request_id: str = Field(min_length=8, max_length=120)
+    rating: Literal["up", "down"]
 
 
 def _extract_api_key(request: Request) -> str | None:
@@ -54,6 +63,10 @@ def _quota_payload(decision: QuotaDecision) -> dict[str, Any]:
         "remaining": decision.remaining,
         "scope": decision.subject,
     }
+
+
+def _stream_event(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False) + "\n"
 
 
 def create_app(
@@ -161,6 +174,104 @@ def create_app(
             "metadata": result.metadata,
             "quota": _quota_payload(decision),
         }
+
+    @app.post("/api/paraphrase/stream")
+    async def paraphrase_stream(payload: ParaphraseRequest, request: Request) -> StreamingResponse:
+        text = payload.text.strip()
+        if len(text) > app.state.settings.max_chars:
+            raise HTTPException(
+                status_code=413,
+                detail=f"Text is too long for the demo limit ({app.state.settings.max_chars} characters).",
+            )
+
+        api_key = _extract_api_key(request)
+        if api_key and not app.state.quota_store.check_api_key(api_key):
+            raise HTTPException(status_code=401, detail="Invalid API key.")
+        decision = app.state.quota_store.consume(api_key=api_key, client_id=_client_id(request))
+        if not decision.allowed:
+            raise HTTPException(
+                status_code=429,
+                detail="Daily demo quota exceeded. Use an API key or try again tomorrow.",
+            )
+
+        request_id = str(uuid.uuid4())
+
+        async def events():
+            start = time.perf_counter()
+            final_output = ""
+            metadata: dict[str, Any] = {}
+            yield _stream_event(
+                {
+                    "event": "status",
+                    "request_id": request_id,
+                    "message": "Request accepted. Waking the StealthRL runtime...",
+                    "tone": "busy",
+                }
+            )
+            try:
+                async with asyncio.timeout(app.state.settings.request_timeout_s):
+                    async for event in app.state.backend.paraphrase_stream(
+                        text=text,
+                        temperature=payload.temperature,
+                        top_p=payload.top_p,
+                    ):
+                        if event.get("event") == "final":
+                            final_output = str(event.get("output_text") or "")
+                            metadata = dict(event.get("metadata") or {})
+                            continue
+                        yield _stream_event({**event, "request_id": request_id})
+
+                latency_ms = int((time.perf_counter() - start) * 1000)
+                yield _stream_event(
+                    {
+                        "event": "final",
+                        "request_id": request_id,
+                        "input_text": text,
+                        "output_text": final_output,
+                        "backend": app.state.backend.name,
+                        "latency_ms": latency_ms,
+                        "metrics": compute_metrics(text, final_output),
+                        "metadata": metadata,
+                        "quota": _quota_payload(decision),
+                    }
+                )
+            except TimeoutError:
+                yield _stream_event(
+                    {
+                        "event": "error",
+                        "request_id": request_id,
+                        "message": "StealthRL inference timed out. The GPU may still be warming up; try again in a few minutes.",
+                    }
+                )
+            except Exception as exc:
+                logger.exception("StealthRL demo streaming inference failed")
+                yield _stream_event(
+                    {
+                        "event": "error",
+                        "request_id": request_id,
+                        "message": f"Inference failed: {exc}",
+                    }
+                )
+
+        return StreamingResponse(
+            events(),
+            media_type="application/x-ndjson",
+            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+        )
+
+    @app.post("/api/feedback")
+    async def feedback(payload: FeedbackRequest, request: Request) -> dict[str, Any]:
+        api_key = _extract_api_key(request)
+        api_key_config = app.state.quota_store.check_api_key(api_key)
+        if api_key and api_key_config is None:
+            raise HTTPException(status_code=401, detail="Invalid API key.")
+        app.state.quota_store.record_feedback(
+            request_id=payload.request_id,
+            rating=payload.rating,
+            client_id=_client_id(request),
+            api_key_label=api_key_config.label if api_key_config is not None else None,
+        )
+        return {"ok": True}
 
     return app
 

--- a/demo/stealthrl_demo/app.py
+++ b/demo/stealthrl_demo/app.py
@@ -84,6 +84,10 @@ def create_app(
     async def index() -> FileResponse:
         return FileResponse(STATIC_DIR / "index.html")
 
+    @app.get("/privacy", include_in_schema=False)
+    async def privacy() -> FileResponse:
+        return FileResponse(STATIC_DIR / "privacy.html")
+
     @app.get("/api/health")
     async def health() -> dict[str, Any]:
         return {

--- a/demo/stealthrl_demo/app.py
+++ b/demo/stealthrl_demo/app.py
@@ -1,0 +1,155 @@
+"""FastAPI application for the StealthRL demo website."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field
+
+from .config import DemoSettings, load_settings
+from .inference import BaseDemoBackend, build_backend, run_paraphrase
+from .rate_limit import QuotaDecision, QuotaStore
+
+logger = logging.getLogger(__name__)
+
+STATIC_DIR = Path(__file__).resolve().parents[1] / "static"
+
+
+class ParaphraseRequest(BaseModel):
+    text: str = Field(min_length=20)
+    temperature: float = Field(default=0.9, ge=0.0, le=1.5)
+    top_p: float = Field(default=0.95, ge=0.1, le=1.0)
+
+
+def _extract_api_key(request: Request) -> str | None:
+    auth_header = request.headers.get("authorization", "").strip()
+    if auth_header.lower().startswith("bearer "):
+        token = auth_header[7:].strip()
+        if token:
+            return token
+    key = request.headers.get("x-stealthrl-api-key", "").strip()
+    return key or None
+
+
+def _client_id(request: Request) -> str:
+    forwarded = request.headers.get("x-forwarded-for", "").strip()
+    if forwarded:
+        return forwarded.split(",", 1)[0].strip()
+    if request.client and request.client.host:
+        return request.client.host
+    return "unknown"
+
+
+def _quota_payload(decision: QuotaDecision) -> dict[str, Any]:
+    return {
+        "authenticated": decision.authenticated,
+        "label": decision.label,
+        "limit": decision.limit,
+        "remaining": decision.remaining,
+        "scope": decision.subject,
+    }
+
+
+def create_app(
+    settings: DemoSettings | None = None,
+    quota_store: QuotaStore | None = None,
+    backend: BaseDemoBackend | None = None,
+) -> FastAPI:
+    settings = settings or load_settings()
+    quota_store = quota_store or QuotaStore(
+        db_path=settings.db_path,
+        api_keys=settings.api_keys,
+        public_daily_limit=settings.public_daily_limit,
+        public_quota_scope=settings.public_quota_scope,
+    )
+    backend = backend or build_backend(settings)
+
+    app = FastAPI(
+        title="StealthRL Demo",
+        description="Interactive StealthRL paraphrase demo with API-key and public quota controls.",
+        version="0.1.0",
+    )
+    app.state.settings = settings
+    app.state.quota_store = quota_store
+    app.state.backend = backend
+
+    app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+    @app.get("/", include_in_schema=False)
+    async def index() -> FileResponse:
+        return FileResponse(STATIC_DIR / "index.html")
+
+    @app.get("/api/health")
+    async def health() -> dict[str, Any]:
+        return {
+            "ok": True,
+            "backend": app.state.backend.name,
+            "public_daily_limit": app.state.settings.public_daily_limit,
+            "public_quota_scope": app.state.settings.public_quota_scope,
+        }
+
+    @app.get("/api/config")
+    async def public_config(request: Request) -> dict[str, Any]:
+        decision = app.state.quota_store.peek_public(_client_id(request))
+        return {
+            "backend": app.state.backend.name,
+            "max_chars": app.state.settings.max_chars,
+            "public_daily_limit": app.state.settings.public_daily_limit,
+            "public_quota_scope": app.state.settings.public_quota_scope,
+            "api_keys_enabled": bool(app.state.settings.api_keys),
+            "public_quota": _quota_payload(decision),
+        }
+
+    @app.post("/api/paraphrase")
+    async def paraphrase(payload: ParaphraseRequest, request: Request) -> dict[str, Any]:
+        text = payload.text.strip()
+        if len(text) > app.state.settings.max_chars:
+            raise HTTPException(
+                status_code=413,
+                detail=f"Text is too long for the demo limit ({app.state.settings.max_chars} characters).",
+            )
+
+        api_key = _extract_api_key(request)
+        if api_key and not app.state.quota_store.check_api_key(api_key):
+            raise HTTPException(status_code=401, detail="Invalid API key.")
+        decision = app.state.quota_store.consume(api_key=api_key, client_id=_client_id(request))
+        if not decision.allowed:
+            raise HTTPException(
+                status_code=429,
+                detail="Daily demo quota exceeded. Use an API key or try again tomorrow.",
+            )
+
+        try:
+            result = await run_paraphrase(
+                backend=app.state.backend,
+                text=text,
+                temperature=payload.temperature,
+                top_p=payload.top_p,
+                timeout_s=app.state.settings.request_timeout_s,
+            )
+        except TimeoutError:
+            raise HTTPException(status_code=504, detail="StealthRL inference timed out.")
+        except Exception as exc:
+            logger.exception("StealthRL demo inference failed")
+            raise HTTPException(status_code=500, detail=f"Inference failed: {exc}")
+
+        return {
+            "request_id": result.request_id,
+            "input_text": result.input_text,
+            "output_text": result.output_text,
+            "backend": result.backend,
+            "latency_ms": result.latency_ms,
+            "metrics": result.metrics,
+            "metadata": result.metadata,
+            "quota": _quota_payload(decision),
+        }
+
+    return app
+
+
+app = create_app()

--- a/demo/stealthrl_demo/app.py
+++ b/demo/stealthrl_demo/app.py
@@ -66,7 +66,7 @@ def _quota_payload(decision: QuotaDecision) -> dict[str, Any]:
 
 
 def _stream_event(payload: dict[str, Any]) -> str:
-    return json.dumps(payload, ensure_ascii=False) + "\n"
+    return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
 
 
 def create_app(
@@ -255,8 +255,8 @@ def create_app(
 
         return StreamingResponse(
             events(),
-            media_type="application/x-ndjson",
-            headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+            media_type="text/event-stream",
+            headers={"Cache-Control": "no-cache, no-transform", "X-Accel-Buffering": "no"},
         )
 
     @app.post("/api/feedback")

--- a/demo/stealthrl_demo/config.py
+++ b/demo/stealthrl_demo/config.py
@@ -29,6 +29,7 @@ class DemoSettings:
     hf_adapter_model: str = "suraj-ranganath/StealthRL"
     hf_dtype: str = "bfloat16"
     hf_device_map: str = "auto"
+    cors_origins: tuple[str, ...] = ()
     max_chars: int = 5000
     request_timeout_s: int = 90
 
@@ -66,6 +67,12 @@ def _parse_api_keys(raw: str | None) -> tuple[ApiKeyConfig, ...]:
     return tuple(configs)
 
 
+def _parse_csv_env(raw: str | None) -> tuple[str, ...]:
+    if not raw or not raw.strip():
+        return ()
+    return tuple(item.strip().rstrip("/") for item in raw.split(",") if item.strip())
+
+
 def load_settings() -> DemoSettings:
     quota_scope = os.getenv("STEALTHRL_DEMO_PUBLIC_QUOTA_SCOPE", "ip").strip().lower()
     if quota_scope not in {"ip", "global"}:
@@ -82,6 +89,7 @@ def load_settings() -> DemoSettings:
         hf_adapter_model=os.getenv("STEALTHRL_DEMO_HF_ADAPTER_MODEL", "suraj-ranganath/StealthRL").strip(),
         hf_dtype=os.getenv("STEALTHRL_DEMO_HF_DTYPE", "bfloat16").strip().lower(),
         hf_device_map=os.getenv("STEALTHRL_DEMO_HF_DEVICE_MAP", "auto").strip(),
+        cors_origins=_parse_csv_env(os.getenv("STEALTHRL_DEMO_CORS_ORIGINS")),
         max_chars=_int_env("STEALTHRL_DEMO_MAX_CHARS", 5000),
         request_timeout_s=_int_env("STEALTHRL_DEMO_REQUEST_TIMEOUT_S", 90),
     )

--- a/demo/stealthrl_demo/config.py
+++ b/demo/stealthrl_demo/config.py
@@ -1,0 +1,79 @@
+"""Configuration helpers for the StealthRL demo service."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class ApiKeyConfig:
+    key: str
+    label: str
+    daily_limit: int | None = None
+
+
+@dataclass(frozen=True)
+class DemoSettings:
+    app_name: str = "StealthRL Demo"
+    public_daily_limit: int = 20
+    public_quota_scope: str = "ip"
+    db_path: Path = Path("demo/demo_usage.sqlite3")
+    api_keys: tuple[ApiKeyConfig, ...] = ()
+    inference_backend: str = "mock"
+    checkpoint_json: str | None = None
+    max_chars: int = 5000
+    request_timeout_s: int = 90
+
+
+def _int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or not raw.strip():
+        return default
+    return int(raw)
+
+
+def _parse_api_keys(raw: str | None) -> tuple[ApiKeyConfig, ...]:
+    if not raw or not raw.strip():
+        return ()
+
+    raw = raw.strip()
+    configs: list[ApiKeyConfig] = []
+    if raw.startswith("{"):
+        payload: dict[str, Any] = json.loads(raw)
+        for key, meta in payload.items():
+            if isinstance(meta, dict):
+                label = str(meta.get("label") or key[-6:])
+                daily_limit = meta.get("daily_limit")
+                daily_limit = int(daily_limit) if daily_limit is not None else None
+            else:
+                label = str(meta or key[-6:])
+                daily_limit = None
+            configs.append(ApiKeyConfig(key=key, label=label, daily_limit=daily_limit))
+        return tuple(configs)
+
+    for item in raw.split(","):
+        key = item.strip()
+        if key:
+            configs.append(ApiKeyConfig(key=key, label=key[-6:]))
+    return tuple(configs)
+
+
+def load_settings() -> DemoSettings:
+    quota_scope = os.getenv("STEALTHRL_DEMO_PUBLIC_QUOTA_SCOPE", "ip").strip().lower()
+    if quota_scope not in {"ip", "global"}:
+        raise ValueError("STEALTHRL_DEMO_PUBLIC_QUOTA_SCOPE must be 'ip' or 'global'")
+
+    return DemoSettings(
+        public_daily_limit=_int_env("STEALTHRL_DEMO_PUBLIC_DAILY_LIMIT", 20),
+        public_quota_scope=quota_scope,
+        db_path=Path(os.getenv("STEALTHRL_DEMO_DB_PATH", "demo/demo_usage.sqlite3")),
+        api_keys=_parse_api_keys(os.getenv("STEALTHRL_DEMO_API_KEYS")),
+        inference_backend=os.getenv("STEALTHRL_DEMO_INFERENCE_BACKEND", "mock").strip().lower(),
+        checkpoint_json=os.getenv("STEALTHRL_DEMO_CHECKPOINT_JSON") or None,
+        max_chars=_int_env("STEALTHRL_DEMO_MAX_CHARS", 5000),
+        request_timeout_s=_int_env("STEALTHRL_DEMO_REQUEST_TIMEOUT_S", 90),
+    )

--- a/demo/stealthrl_demo/config.py
+++ b/demo/stealthrl_demo/config.py
@@ -25,6 +25,10 @@ class DemoSettings:
     api_keys: tuple[ApiKeyConfig, ...] = ()
     inference_backend: str = "mock"
     checkpoint_json: str | None = None
+    hf_base_model: str = "Qwen/Qwen3-4B-Instruct-2507"
+    hf_adapter_model: str = "suraj-ranganath/StealthRL"
+    hf_dtype: str = "bfloat16"
+    hf_device_map: str = "auto"
     max_chars: int = 5000
     request_timeout_s: int = 90
 
@@ -74,6 +78,10 @@ def load_settings() -> DemoSettings:
         api_keys=_parse_api_keys(os.getenv("STEALTHRL_DEMO_API_KEYS")),
         inference_backend=os.getenv("STEALTHRL_DEMO_INFERENCE_BACKEND", "mock").strip().lower(),
         checkpoint_json=os.getenv("STEALTHRL_DEMO_CHECKPOINT_JSON") or None,
+        hf_base_model=os.getenv("STEALTHRL_DEMO_HF_BASE_MODEL", "Qwen/Qwen3-4B-Instruct-2507").strip(),
+        hf_adapter_model=os.getenv("STEALTHRL_DEMO_HF_ADAPTER_MODEL", "suraj-ranganath/StealthRL").strip(),
+        hf_dtype=os.getenv("STEALTHRL_DEMO_HF_DTYPE", "bfloat16").strip().lower(),
+        hf_device_map=os.getenv("STEALTHRL_DEMO_HF_DEVICE_MAP", "auto").strip(),
         max_chars=_int_env("STEALTHRL_DEMO_MAX_CHARS", 5000),
         request_timeout_s=_int_env("STEALTHRL_DEMO_REQUEST_TIMEOUT_S", 90),
     )

--- a/demo/stealthrl_demo/inference.py
+++ b/demo/stealthrl_demo/inference.py
@@ -6,12 +6,13 @@ import asyncio
 import json
 import random
 import re
+import threading
 import time
 import uuid
 from dataclasses import dataclass
 from difflib import SequenceMatcher
 from pathlib import Path
-from typing import Any
+from typing import Any, AsyncIterator
 
 from .config import DemoSettings
 
@@ -40,6 +41,28 @@ class BaseDemoBackend:
 
     async def paraphrase(self, text: str, temperature: float, top_p: float) -> tuple[str, dict[str, Any]]:
         raise NotImplementedError
+
+    async def paraphrase_stream(
+        self,
+        text: str,
+        temperature: float,
+        top_p: float,
+    ) -> AsyncIterator[dict[str, Any]]:
+        yield {
+            "event": "status",
+            "message": "Running StealthRL generation.",
+            "tone": "busy",
+        }
+        output, metadata = await self.paraphrase(text=text, temperature=temperature, top_p=top_p)
+        yield {
+            "event": "delta",
+            "text": output,
+        }
+        yield {
+            "event": "final",
+            "output_text": output,
+            "metadata": metadata,
+        }
 
 
 class MockStealthBackend(BaseDemoBackend):
@@ -251,6 +274,128 @@ class HuggingFaceStealthBackend(BaseDemoBackend):
             "adapter_model": runtime["adapter_model"],
             "chunk_count": len(chunks),
         }
+
+    async def paraphrase_stream(
+        self,
+        text: str,
+        temperature: float,
+        top_p: float,
+    ) -> AsyncIterator[dict[str, Any]]:
+        yield {
+            "event": "status",
+            "message": "Loading StealthRL weights. If the GPU has been idle, this first step can take a few minutes.",
+            "tone": "busy",
+        }
+        runtime = await self._ensure_loaded()
+        chunks = _split_generation_chunks(text)
+        raw_parts: list[str] = []
+
+        for index, chunk in enumerate(chunks, start=1):
+            yield {
+                "event": "status",
+                "message": f"Generating rewrite chunk {index}/{len(chunks)}...",
+                "tone": "busy",
+            }
+            async for piece in self._stream_generate_one(
+                runtime=runtime,
+                chunk=chunk,
+                temperature=temperature,
+                top_p=top_p,
+            ):
+                raw_parts.append(piece)
+                yield {
+                    "event": "delta",
+                    "text": piece,
+                }
+            if index < len(chunks):
+                raw_parts.append(" ")
+                yield {
+                    "event": "delta",
+                    "text": " ",
+                }
+
+        output = _clean_model_output("".join(raw_parts))
+        yield {
+            "event": "final",
+            "output_text": output,
+            "metadata": {
+                "method": "stealthrl",
+                "backend": "hf_peft",
+                "base_model": runtime["base_model"],
+                "adapter_model": runtime["adapter_model"],
+                "chunk_count": len(chunks),
+                "streaming": True,
+            },
+        }
+
+    async def _stream_generate_one(
+        self,
+        runtime: dict[str, Any],
+        chunk: str,
+        temperature: float,
+        top_p: float,
+    ) -> AsyncIterator[str]:
+        import torch
+        from transformers import TextIteratorStreamer
+
+        model = runtime["model"]
+        tokenizer = runtime["tokenizer"]
+        prompt_text = PARAPHRASE_PROMPT.format(text=chunk)
+        messages = [{"role": "user", "content": prompt_text}]
+        if hasattr(tokenizer, "apply_chat_template"):
+            formatted = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        else:
+            formatted = prompt_text
+
+        inputs = tokenizer(
+            formatted,
+            return_tensors="pt",
+            truncation=True,
+            max_length=1024,
+        ).to(model.device)
+        streamer = TextIteratorStreamer(
+            tokenizer,
+            skip_prompt=True,
+            skip_special_tokens=True,
+        )
+        errors: list[BaseException] = []
+
+        def _generate() -> None:
+            try:
+                with torch.no_grad():
+                    model.generate(
+                        **inputs,
+                        max_new_tokens=_estimate_generation_max_tokens(chunk, default_max_tokens=512),
+                        do_sample=temperature > 0,
+                        temperature=max(temperature, 1e-5),
+                        top_p=top_p,
+                        pad_token_id=tokenizer.eos_token_id,
+                        streamer=streamer,
+                    )
+            except BaseException as exc:
+                errors.append(exc)
+                streamer.on_finalized_text("", stream_end=True)
+
+        thread = threading.Thread(target=_generate, daemon=True)
+        thread.start()
+        sentinel = object()
+
+        def _next_piece() -> str | object:
+            try:
+                return next(streamer)
+            except StopIteration:
+                return sentinel
+
+        while True:
+            piece = await asyncio.to_thread(_next_piece)
+            if piece is sentinel:
+                break
+            if piece:
+                yield str(piece)
+
+        thread.join(timeout=1)
+        if errors:
+            raise errors[0]
 
 
 def build_backend(settings: DemoSettings) -> BaseDemoBackend:

--- a/demo/stealthrl_demo/inference.py
+++ b/demo/stealthrl_demo/inference.py
@@ -16,6 +16,14 @@ from typing import Any
 from .config import DemoSettings
 
 
+PARAPHRASE_PROMPT = """Please paraphrase the following text while maintaining its meaning and style. Preserve every source claim, keep the paraphrase close to the original length, do not summarize, do not add new details, and output only the paraphrased text without any additional explanation.
+
+Original text:
+{text}
+
+Paraphrased text:"""
+
+
 @dataclass(frozen=True)
 class ParaphraseResult:
     request_id: str
@@ -67,7 +75,7 @@ class MockStealthBackend(BaseDemoBackend):
             output = text.strip()
         return output, {
             "mode": "deterministic_preview",
-            "note": "Set STEALTHRL_DEMO_INFERENCE_BACKEND=tinker for real StealthRL sampler calls.",
+            "note": "Set STEALTHRL_DEMO_INFERENCE_BACKEND=hf for real StealthRL adapter inference.",
         }
 
     def _rewrite_sentence(self, sentence: str, idx: int) -> str:
@@ -154,11 +162,104 @@ class TinkerStealthBackend(BaseDemoBackend):
         }
 
 
+class HuggingFaceStealthBackend(BaseDemoBackend):
+    name = "hf"
+
+    def __init__(self, settings: DemoSettings) -> None:
+        self.settings = settings
+        self._runtime: dict[str, Any] | None = None
+        self._lock = asyncio.Lock()
+
+    async def _ensure_loaded(self) -> dict[str, Any]:
+        if self._runtime is not None:
+            return self._runtime
+        async with self._lock:
+            if self._runtime is not None:
+                return self._runtime
+
+            def _load() -> dict[str, Any]:
+                import torch
+                from peft import PeftModel
+                from transformers import AutoModelForCausalLM, AutoTokenizer
+
+                dtype = _torch_dtype(torch, self.settings.hf_dtype)
+                tokenizer = AutoTokenizer.from_pretrained(
+                    self.settings.hf_base_model,
+                    trust_remote_code=True,
+                )
+                model = AutoModelForCausalLM.from_pretrained(
+                    self.settings.hf_base_model,
+                    dtype=dtype,
+                    device_map=self.settings.hf_device_map,
+                    trust_remote_code=True,
+                )
+                model = PeftModel.from_pretrained(model, self.settings.hf_adapter_model)
+                model.eval()
+                return {
+                    "model": model,
+                    "tokenizer": tokenizer,
+                    "base_model": self.settings.hf_base_model,
+                    "adapter_model": self.settings.hf_adapter_model,
+                }
+
+            self._runtime = await asyncio.to_thread(_load)
+            return self._runtime
+
+    async def paraphrase(self, text: str, temperature: float, top_p: float) -> tuple[str, dict[str, Any]]:
+        runtime = await self._ensure_loaded()
+        chunks = _split_generation_chunks(text)
+
+        def _generate_one(chunk: str) -> str:
+            import torch
+
+            model = runtime["model"]
+            tokenizer = runtime["tokenizer"]
+            prompt_text = PARAPHRASE_PROMPT.format(text=chunk)
+            messages = [{"role": "user", "content": prompt_text}]
+            if hasattr(tokenizer, "apply_chat_template"):
+                formatted = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+            else:
+                formatted = prompt_text
+
+            inputs = tokenizer(
+                formatted,
+                return_tensors="pt",
+                truncation=True,
+                max_length=1024,
+            ).to(model.device)
+            with torch.no_grad():
+                output_ids = model.generate(
+                    **inputs,
+                    max_new_tokens=_estimate_generation_max_tokens(text, default_max_tokens=512),
+                    do_sample=temperature > 0,
+                    temperature=max(temperature, 1e-5),
+                    top_p=top_p,
+                    pad_token_id=tokenizer.eos_token_id,
+                )
+            new_tokens = output_ids[0, inputs["input_ids"].shape[1] :]
+            output = tokenizer.decode(new_tokens, skip_special_tokens=True).strip()
+            return _clean_model_output(output)
+
+        def _run() -> str:
+            return " ".join(_generate_one(chunk) for chunk in chunks).strip()
+
+        output = await asyncio.to_thread(_run)
+        return output, {
+            "method": "stealthrl",
+            "backend": "hf_peft",
+            "base_model": runtime["base_model"],
+            "adapter_model": runtime["adapter_model"],
+            "chunk_count": len(chunks),
+        }
+
+
 def build_backend(settings: DemoSettings) -> BaseDemoBackend:
     if settings.inference_backend == "tinker":
         return TinkerStealthBackend(settings)
+    if settings.inference_backend in {"hf", "huggingface", "peft"}:
+        return HuggingFaceStealthBackend(settings)
     if settings.inference_backend != "mock":
-        raise ValueError("STEALTHRL_DEMO_INFERENCE_BACKEND must be 'mock' or 'tinker'")
+        raise ValueError("STEALTHRL_DEMO_INFERENCE_BACKEND must be 'mock', 'tinker', or 'hf'")
     return MockStealthBackend()
 
 
@@ -212,6 +313,50 @@ def _estimate_generation_max_tokens(original: str, default_max_tokens: int, min_
     char_based = max(int(len(original) / 6), min_tokens)
     word_based = max(int(word_count * 1.6), min_tokens)
     return min(default_max_tokens, max(char_based, word_based))
+
+
+def _split_generation_chunks(text: str, max_chunks: int = 12) -> list[str]:
+    sentences = _split_sentences(text)
+    if len(sentences) <= 1:
+        return [text.strip()]
+    if len(sentences) <= max_chunks:
+        return sentences
+
+    chunk_size = max(1, (len(sentences) + max_chunks - 1) // max_chunks)
+    chunks = []
+    for start in range(0, len(sentences), chunk_size):
+        chunks.append(" ".join(sentences[start : start + chunk_size]).strip())
+    return chunks
+
+
+def _torch_dtype(torch: Any, dtype_name: str) -> Any:
+    if dtype_name in {"auto", ""}:
+        return "auto"
+    if dtype_name in {"bf16", "bfloat16"}:
+        return torch.bfloat16
+    if dtype_name in {"fp16", "float16", "half"}:
+        return torch.float16
+    if dtype_name in {"fp32", "float32", "float"}:
+        return torch.float32
+    raise ValueError("STEALTHRL_DEMO_HF_DTYPE must be one of: auto, bfloat16, float16, float32")
+
+
+def _clean_model_output(output: str) -> str:
+    text = output.strip()
+    text = re.sub(r"<think>.*?</think>", "", text, flags=re.DOTALL | re.IGNORECASE).strip()
+    for marker in ("PARAPHRASE:", "Paraphrase:", "paraphrase:"):
+        if marker in text:
+            text = text.split(marker, 1)[-1].strip()
+    lines = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.lower().startswith(("note:", "(note:")):
+            continue
+        lines.append(stripped)
+    text = " ".join(lines).strip().strip('"')
+    return text or output.strip()
 
 
 def _normalize_spacing(text: str) -> str:

--- a/demo/stealthrl_demo/inference.py
+++ b/demo/stealthrl_demo/inference.py
@@ -1,0 +1,225 @@
+"""Inference backends for the StealthRL demo."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+import re
+import time
+import uuid
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any
+
+from .config import DemoSettings
+
+
+@dataclass(frozen=True)
+class ParaphraseResult:
+    request_id: str
+    input_text: str
+    output_text: str
+    backend: str
+    latency_ms: int
+    metrics: dict[str, Any]
+    metadata: dict[str, Any]
+
+
+class BaseDemoBackend:
+    name = "base"
+
+    async def paraphrase(self, text: str, temperature: float, top_p: float) -> tuple[str, dict[str, Any]]:
+        raise NotImplementedError
+
+
+class MockStealthBackend(BaseDemoBackend):
+    """Deterministic, no-cost paraphraser for local and public UI testing."""
+
+    name = "mock"
+
+    _phrase_swaps = (
+        (r"\bAI-generated text\b", "machine-written prose"),
+        (r"\bAI text\b", "machine-written text"),
+        (r"\bdetectors\b", "detection systems"),
+        (r"\brobustness\b", "resilience"),
+        (r"\bevaluate\b", "assess"),
+        (r"\bevaluation\b", "assessment"),
+        (r"\bhowever\b", "still"),
+        (r"\btherefore\b", "as a result"),
+        (r"\bimportant\b", "central"),
+        (r"\bsignificant\b", "substantial"),
+    )
+
+    async def paraphrase(self, text: str, temperature: float, top_p: float) -> tuple[str, dict[str, Any]]:
+        await asyncio.sleep(0)
+        sentences = _split_sentences(text)
+        rewritten: list[str] = []
+        for idx, sentence in enumerate(sentences):
+            clean = sentence.strip()
+            if not clean:
+                continue
+            clean = self._rewrite_sentence(clean, idx)
+            rewritten.append(clean)
+        output = " ".join(rewritten).strip()
+        if not output:
+            output = text.strip()
+        return output, {
+            "mode": "deterministic_preview",
+            "note": "Set STEALTHRL_DEMO_INFERENCE_BACKEND=tinker for real StealthRL sampler calls.",
+        }
+
+    def _rewrite_sentence(self, sentence: str, idx: int) -> str:
+        out = sentence
+        for pattern, repl in self._phrase_swaps:
+            out = re.sub(pattern, repl, out, flags=re.IGNORECASE)
+        if idx % 3 == 1 and "," in out:
+            head, tail = out.split(",", 1)
+            if 4 <= len(head.split()) <= 18:
+                out = f"{tail.strip().rstrip('.')}, {head.strip().lower()}."
+        elif idx % 3 == 2 and len(out.split()) > 14:
+            out = re.sub(r"\bThis\b", "The result", out, count=1)
+            out = re.sub(r"\bIt\b", "This pattern", out, count=1)
+        return _normalize_spacing(out)
+
+
+class TinkerStealthBackend(BaseDemoBackend):
+    name = "tinker"
+
+    def __init__(self, settings: DemoSettings) -> None:
+        if not settings.checkpoint_json:
+            raise RuntimeError("STEALTHRL_DEMO_CHECKPOINT_JSON is required for tinker backend")
+        self.settings = settings
+        self._runtime: dict[str, Any] | None = None
+        self._lock = asyncio.Lock()
+
+    async def _ensure_loaded(self) -> dict[str, Any]:
+        if self._runtime is not None:
+            return self._runtime
+        async with self._lock:
+            if self._runtime is not None:
+                return self._runtime
+
+            def _load() -> dict[str, Any]:
+                from tinker import ServiceClient
+
+                checkpoint = json.loads(Path(self.settings.checkpoint_json).read_text())
+                sampler_path = checkpoint["checkpoints"]["sampler_weights"]
+                service_client = ServiceClient()
+                sampling_client = service_client.create_sampling_client(model_path=sampler_path)
+                tokenizer = sampling_client.get_tokenizer()
+                return {
+                    "checkpoint": checkpoint,
+                    "sampler_path": sampler_path,
+                    "sampling_client": sampling_client,
+                    "tokenizer": tokenizer,
+                }
+
+            self._runtime = await asyncio.to_thread(_load)
+            return self._runtime
+
+    async def paraphrase(self, text: str, temperature: float, top_p: float) -> tuple[str, dict[str, Any]]:
+        runtime = await self._ensure_loaded()
+
+        def _run() -> str:
+            from tinker import types
+
+            tokenizer = runtime["tokenizer"]
+            prompt_text = PARAPHRASE_PROMPT.format(text=text)
+            messages = [{"role": "user", "content": prompt_text}]
+            formatted = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+            input_ids = tokenizer.encode(formatted)
+            model_input = types.ModelInput.from_ints(input_ids)
+            params = types.SamplingParams(
+                max_tokens=_estimate_generation_max_tokens(text, default_max_tokens=512),
+                temperature=temperature,
+                top_p=top_p,
+            )
+            future = runtime["sampling_client"].sample(
+                prompt=model_input,
+                sampling_params=params,
+                num_samples=1,
+            )
+            result = future.result()
+            if not result.sequences:
+                raise RuntimeError("Tinker sampler returned no sequences")
+            return tokenizer.decode(result.sequences[0].tokens, skip_special_tokens=True).strip()
+
+        output = await asyncio.to_thread(_run)
+        return output, {
+            "method": "stealthrl",
+            "backend": "tinker",
+            "sampler_path": runtime["sampler_path"],
+        }
+
+
+def build_backend(settings: DemoSettings) -> BaseDemoBackend:
+    if settings.inference_backend == "tinker":
+        return TinkerStealthBackend(settings)
+    if settings.inference_backend != "mock":
+        raise ValueError("STEALTHRL_DEMO_INFERENCE_BACKEND must be 'mock' or 'tinker'")
+    return MockStealthBackend()
+
+
+async def run_paraphrase(
+    backend: BaseDemoBackend,
+    text: str,
+    temperature: float,
+    top_p: float,
+    timeout_s: int,
+) -> ParaphraseResult:
+    start = time.perf_counter()
+    output, metadata = await asyncio.wait_for(
+        backend.paraphrase(text=text, temperature=temperature, top_p=top_p),
+        timeout=timeout_s,
+    )
+    latency_ms = int((time.perf_counter() - start) * 1000)
+    return ParaphraseResult(
+        request_id=str(uuid.uuid4()),
+        input_text=text,
+        output_text=output,
+        backend=backend.name,
+        latency_ms=latency_ms,
+        metrics=compute_metrics(text, output),
+        metadata=metadata,
+    )
+
+
+def compute_metrics(input_text: str, output_text: str) -> dict[str, Any]:
+    input_words = len(input_text.split())
+    output_words = len(output_text.split())
+    ratio = SequenceMatcher(None, input_text, output_text).ratio()
+    word_delta_pct = 0.0
+    if input_words:
+        word_delta_pct = ((output_words - input_words) / input_words) * 100.0
+    return {
+        "input_words": input_words,
+        "output_words": output_words,
+        "word_delta_pct": round(word_delta_pct, 1),
+        "char_edit_rate": round(1.0 - ratio, 3),
+        "length_ratio": round((len(output_text) / max(1, len(input_text))), 3),
+    }
+
+
+def _split_sentences(text: str) -> list[str]:
+    pieces = re.split(r"(?<=[.!?])\s+", text.strip())
+    return [piece for piece in pieces if piece]
+
+
+def _estimate_generation_max_tokens(original: str, default_max_tokens: int, min_tokens: int = 64) -> int:
+    word_count = len(original.split())
+    char_based = max(int(len(original) / 6), min_tokens)
+    word_based = max(int(word_count * 1.6), min_tokens)
+    return min(default_max_tokens, max(char_based, word_based))
+
+
+def _normalize_spacing(text: str) -> str:
+    text = re.sub(r"\s+", " ", text).strip()
+    text = re.sub(r"\s+([,.;:!?])", r"\1", text)
+    if text and text[-1] not in ".!?":
+        text += "."
+    # Tiny deterministic variation to avoid every preview feeling templated.
+    if len(text.split()) > 22 and random.Random(text).random() < 0.18:
+        text = text.replace(" and ", "; and ", 1)
+    return text

--- a/demo/stealthrl_demo/rate_limit.py
+++ b/demo/stealthrl_demo/rate_limit.py
@@ -1,0 +1,175 @@
+"""SQLite-backed API-key and public quota accounting."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import hmac
+import sqlite3
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from .config import ApiKeyConfig
+
+
+@dataclass(frozen=True)
+class QuotaDecision:
+    allowed: bool
+    authenticated: bool
+    limit: int | None
+    remaining: int | None
+    subject: str
+    label: str
+    reason: str | None = None
+
+
+class QuotaStore:
+    def __init__(
+        self,
+        db_path: Path,
+        api_keys: Iterable[ApiKeyConfig],
+        public_daily_limit: int,
+        public_quota_scope: str = "ip",
+    ) -> None:
+        self.db_path = db_path
+        self.api_keys = tuple(api_keys)
+        self.public_daily_limit = public_daily_limit
+        self.public_quota_scope = public_quota_scope
+        self._lock = threading.Lock()
+        self._init_db()
+
+    def _init_db(self) -> None:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        with sqlite3.connect(self.db_path) as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS usage_counts (
+                    day TEXT NOT NULL,
+                    subject_hash TEXT NOT NULL,
+                    scope TEXT NOT NULL,
+                    count INTEGER NOT NULL DEFAULT 0,
+                    updated_at TEXT NOT NULL,
+                    PRIMARY KEY (day, subject_hash, scope)
+                )
+                """
+            )
+            conn.commit()
+
+    @staticmethod
+    def today_utc() -> str:
+        return dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d")
+
+    @staticmethod
+    def _hash_subject(subject: str) -> str:
+        return hashlib.sha256(subject.encode("utf-8")).hexdigest()
+
+    def _match_api_key(self, api_key: str | None) -> ApiKeyConfig | None:
+        if not api_key:
+            return None
+        for candidate in self.api_keys:
+            if hmac.compare_digest(api_key, candidate.key):
+                return candidate
+        return None
+
+    def check_api_key(self, api_key: str | None) -> ApiKeyConfig | None:
+        return self._match_api_key(api_key)
+
+    def consume(self, api_key: str | None, client_id: str) -> QuotaDecision:
+        key_config = self._match_api_key(api_key)
+        if key_config is not None:
+            if key_config.daily_limit is None:
+                return QuotaDecision(
+                    allowed=True,
+                    authenticated=True,
+                    limit=None,
+                    remaining=None,
+                    subject="api-key",
+                    label=key_config.label,
+                )
+            return self._consume_subject(
+                subject=f"api:{key_config.key}",
+                scope="api_key",
+                limit=key_config.daily_limit,
+                authenticated=True,
+                label=key_config.label,
+            )
+
+        public_subject = "public:global" if self.public_quota_scope == "global" else f"public:{client_id}"
+        return self._consume_subject(
+            subject=public_subject,
+            scope=f"public_{self.public_quota_scope}",
+            limit=self.public_daily_limit,
+            authenticated=False,
+            label="public",
+        )
+
+    def _consume_subject(
+        self,
+        subject: str,
+        scope: str,
+        limit: int,
+        authenticated: bool,
+        label: str,
+    ) -> QuotaDecision:
+        day = self.today_utc()
+        subject_hash = self._hash_subject(subject)
+        now = dt.datetime.now(dt.timezone.utc).isoformat()
+        with self._lock:
+            with sqlite3.connect(self.db_path, timeout=10) as conn:
+                row = conn.execute(
+                    "SELECT count FROM usage_counts WHERE day=? AND subject_hash=? AND scope=?",
+                    (day, subject_hash, scope),
+                ).fetchone()
+                count = int(row[0]) if row else 0
+                if count >= limit:
+                    return QuotaDecision(
+                        allowed=False,
+                        authenticated=authenticated,
+                        limit=limit,
+                        remaining=0,
+                        subject=scope,
+                        label=label,
+                        reason="daily_quota_exceeded",
+                    )
+                count += 1
+                conn.execute(
+                    """
+                    INSERT INTO usage_counts(day, subject_hash, scope, count, updated_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    ON CONFLICT(day, subject_hash, scope)
+                    DO UPDATE SET count=excluded.count, updated_at=excluded.updated_at
+                    """,
+                    (day, subject_hash, scope, count, now),
+                )
+                conn.commit()
+        return QuotaDecision(
+            allowed=True,
+            authenticated=authenticated,
+            limit=limit,
+            remaining=max(0, limit - count),
+            subject=scope,
+            label=label,
+        )
+
+    def peek_public(self, client_id: str) -> QuotaDecision:
+        day = self.today_utc()
+        subject = "public:global" if self.public_quota_scope == "global" else f"public:{client_id}"
+        subject_hash = self._hash_subject(subject)
+        scope = f"public_{self.public_quota_scope}"
+        with sqlite3.connect(self.db_path) as conn:
+            row = conn.execute(
+                "SELECT count FROM usage_counts WHERE day=? AND subject_hash=? AND scope=?",
+                (day, subject_hash, scope),
+            ).fetchone()
+        count = int(row[0]) if row else 0
+        return QuotaDecision(
+            allowed=count < self.public_daily_limit,
+            authenticated=False,
+            limit=self.public_daily_limit,
+            remaining=max(0, self.public_daily_limit - count),
+            subject=scope,
+            label="public",
+            reason=None if count < self.public_daily_limit else "daily_quota_exceeded",
+        )

--- a/demo/stealthrl_demo/rate_limit.py
+++ b/demo/stealthrl_demo/rate_limit.py
@@ -55,6 +55,24 @@ class QuotaStore:
                 )
                 """
             )
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS feedback_events (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    request_id TEXT NOT NULL,
+                    rating TEXT NOT NULL CHECK (rating IN ('up', 'down')),
+                    client_hash TEXT NOT NULL,
+                    api_key_label TEXT,
+                    created_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE INDEX IF NOT EXISTS feedback_events_request_id_idx
+                ON feedback_events(request_id)
+                """
+            )
             conn.commit()
 
     @staticmethod
@@ -173,3 +191,24 @@ class QuotaStore:
             label="public",
             reason=None if count < self.public_daily_limit else "daily_quota_exceeded",
         )
+
+    def record_feedback(
+        self,
+        request_id: str,
+        rating: str,
+        client_id: str,
+        api_key_label: str | None,
+    ) -> None:
+        if rating not in {"up", "down"}:
+            raise ValueError("rating must be 'up' or 'down'")
+        now = dt.datetime.now(dt.timezone.utc).isoformat()
+        with self._lock:
+            with sqlite3.connect(self.db_path, timeout=10) as conn:
+                conn.execute(
+                    """
+                    INSERT INTO feedback_events(request_id, rating, client_hash, api_key_label, created_at)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (request_id, rating, self._hash_subject(client_id), api_key_label, now),
+                )
+                conn.commit()

--- a/deploy/azure/README.md
+++ b/deploy/azure/README.md
@@ -1,0 +1,109 @@
+# Azure Deployment
+
+This deploys the StealthRL demo as:
+
+- Azure Static Web Apps Free for the static UI.
+- Azure Container Apps serverless GPU for the FastAPI inference API.
+- Azure Container Registry for the GPU image.
+
+The GPU app uses `Consumption-GPU-NC8as-T4`, `minReplicas=0`, and `maxReplicas=1`.
+
+## Prerequisites
+
+Install and authenticate:
+
+```bash
+az login --use-device-code
+az account set --subscription <SUBSCRIPTION_ID_OR_NAME>
+npm install -g @azure/static-web-apps-cli
+az extension add --name containerapp --upgrade
+```
+
+You also need serverless T4 GPU quota in the target region. Check support with:
+
+```bash
+az containerapp env workload-profile list-supported --location eastus --output table
+```
+
+Look for `Consumption-GPU-NC8as-T4`.
+
+## 1. Deploy the GPU API
+
+Choose a globally unique ACR name. It must be lowercase alphanumeric.
+
+```bash
+export AZURE_RESOURCE_GROUP=stealthrl-demo-rg
+export AZURE_LOCATION=eastus
+export AZURE_ACR_NAME=<uniqueacrname>
+export AZURE_CONTAINERAPP_ENV=stealthrl-demo-env
+export AZURE_CONTAINERAPP_NAME=stealthrl-demo-api
+export STEALTHRL_DEMO_PUBLIC_DAILY_LIMIT=20
+export STEALTHRL_DEMO_PUBLIC_QUOTA_SCOPE=ip
+export STEALTHRL_DEMO_CORS_ORIGINS='*'
+
+# Optional API keys. JSON object gives per-key labels/limits.
+export STEALTHRL_DEMO_API_KEYS='{"stealth-demo-lab":{"label":"lab","daily_limit":500}}'
+
+bash deploy/azure/deploy_aca_gpu.sh
+```
+
+The script prints:
+
+```text
+API URL: https://<container-app-fqdn>
+```
+
+The first build is slow because the Docker image downloads and bakes in:
+
+- `Qwen/Qwen3-4B-Instruct-2507`
+- `suraj-ranganath/StealthRL`
+
+This intentionally makes the image large, but avoids redownloading weights from Hugging Face on every scale-to-zero cold start.
+
+## 2. Deploy the Static Web App
+
+```bash
+export STEALTHRL_API_BASE_URL=https://<container-app-fqdn>
+export AZURE_STATIC_WEBAPP_NAME=stealthrl-demo-web
+export AZURE_STATIC_LOCATION=eastus2
+
+bash deploy/azure/deploy_static_swa.sh
+```
+
+The script prints:
+
+```text
+Static site URL: https://<static-web-app-hostname>
+```
+
+After the Static Web App exists, tighten CORS on the API:
+
+```bash
+export STEALTHRL_DEMO_CORS_ORIGINS=https://<static-web-app-hostname>
+bash deploy/azure/deploy_aca_gpu.sh
+```
+
+If you add a custom domain later, include both origins:
+
+```bash
+export STEALTHRL_DEMO_CORS_ORIGINS=https://<static-web-app-hostname>,https://demo.yourdomain.com
+```
+
+## Cost Controls
+
+- Keep `minReplicas=0`.
+- Keep `maxReplicas=1` until traffic/cost is understood.
+- Use `AZURE_ACR_SKU=Basic` for the cheapest registry.
+- Consider `AZURE_ACR_SKU=Premium` only if cold starts are too slow and you want ACR artifact streaming.
+
+## Current MVP Limitation
+
+The first deployment is synchronous: the browser calls `/api/paraphrase` directly. Azure Container Apps has a 240-second ingress timeout, so if cold starts plus model loading exceed that, the next step is to add a queue-backed async API.
+
+The quota SQLite file is stored inside the container filesystem by default. For strict public quota enforcement across scale-to-zero restarts, mount Azure Files and set:
+
+```bash
+export STEALTHRL_DEMO_DB_PATH=/mnt/stealthrl-data/demo_usage.sqlite3
+```
+
+This is not enabled by the MVP script yet.

--- a/deploy/azure/README.md
+++ b/deploy/azure/README.md
@@ -13,11 +13,12 @@ The GPU app uses `Consumption-GPU-NC8as-T4`, `minReplicas=0`, and `maxReplicas=1
 Install and authenticate:
 
 ```bash
+export PATH="$PWD/.venv-azure/bin:$PWD/.azure-tools/node_modules/.bin:$PATH"
 az login --use-device-code
 az account set --subscription <SUBSCRIPTION_ID_OR_NAME>
-npm install -g @azure/static-web-apps-cli
-az extension add --name containerapp --upgrade
 ```
+
+On this server, Azure CLI is installed locally in `.venv-azure/` and the Static Web Apps CLI is installed locally in `.azure-tools/`. If you are setting up a new machine, install equivalent tools with Azure's official installer and `npm install -g @azure/static-web-apps-cli`, or recreate the local installs.
 
 You also need serverless T4 GPU quota in the target region. Check support with:
 

--- a/deploy/azure/build_static_dist.py
+++ b/deploy/azure/build_static_dist.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Build a static artifact for Azure Static Web Apps."""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import shutil
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--api-base-url", required=True, help="External Container Apps API origin")
+    parser.add_argument("--source", default="demo/static", help="Static source directory")
+    parser.add_argument("--out", default="deploy/azure/static_dist", help="Output directory")
+    args = parser.parse_args()
+
+    source = Path(args.source)
+    out = Path(args.out)
+    if out.exists():
+        shutil.rmtree(out)
+    shutil.copytree(source, out)
+    static_mount = out / "static"
+    static_mount.mkdir(exist_ok=True)
+    for asset_name in ("app.js", "styles.css"):
+        shutil.copy2(source / asset_name, static_mount / asset_name)
+
+    index_path = out / "index.html"
+    index = index_path.read_text(encoding="utf-8")
+    api_base_url = html.escape(args.api_base_url.rstrip("/"), quote=True)
+    marker = '<meta name="stealthrl-api-base-url" content="" />'
+    replacement = f'<meta name="stealthrl-api-base-url" content="{api_base_url}" />'
+    if marker not in index:
+        raise SystemExit(f"Could not find API base URL meta tag in {index_path}")
+    index_path.write_text(index.replace(marker, replacement), encoding="utf-8")
+
+    (out / "staticwebapp.config.json").write_text(
+        json.dumps(
+            {
+                "routes": [
+                    {"route": "/privacy", "rewrite": "/privacy.html"},
+                ],
+                "navigationFallback": {"rewrite": "/index.html"},
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    print(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/deploy/azure/deploy_aca_gpu.sh
+++ b/deploy/azure/deploy_aca_gpu.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v az >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+Azure CLI is required but was not found.
+Install it, then run:
+  az login --use-device-code
+  az account set --subscription <SUBSCRIPTION_ID_OR_NAME>
+EOF
+  exit 1
+fi
+
+az account show >/dev/null
+
+AZURE_RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:-stealthrl-demo-rg}"
+AZURE_LOCATION="${AZURE_LOCATION:-eastus}"
+AZURE_ACR_NAME="${AZURE_ACR_NAME:?Set AZURE_ACR_NAME to a globally unique lowercase registry name, e.g. stealthrldemo123}"
+AZURE_ACR_SKU="${AZURE_ACR_SKU:-Basic}"
+AZURE_CONTAINERAPP_ENV="${AZURE_CONTAINERAPP_ENV:-stealthrl-demo-env}"
+AZURE_CONTAINERAPP_NAME="${AZURE_CONTAINERAPP_NAME:-stealthrl-demo-api}"
+AZURE_WORKLOAD_PROFILE_NAME="${AZURE_WORKLOAD_PROFILE_NAME:-gpu-t4}"
+AZURE_IMAGE_NAME="${AZURE_IMAGE_NAME:-stealthrl-demo-gpu}"
+AZURE_IMAGE_TAG="${AZURE_IMAGE_TAG:-$(git rev-parse --short HEAD 2>/dev/null || date +%Y%m%d%H%M%S)}"
+STEALTHRL_DEMO_CORS_ORIGINS="${STEALTHRL_DEMO_CORS_ORIGINS:-*}"
+STEALTHRL_DEMO_PUBLIC_DAILY_LIMIT="${STEALTHRL_DEMO_PUBLIC_DAILY_LIMIT:-20}"
+STEALTHRL_DEMO_PUBLIC_QUOTA_SCOPE="${STEALTHRL_DEMO_PUBLIC_QUOTA_SCOPE:-ip}"
+STEALTHRL_DEMO_MAX_CHARS="${STEALTHRL_DEMO_MAX_CHARS:-5000}"
+STEALTHRL_DEMO_API_KEYS="${STEALTHRL_DEMO_API_KEYS:-}"
+
+az provider register --namespace Microsoft.App --wait
+az provider register --namespace Microsoft.OperationalInsights --wait
+az provider register --namespace Microsoft.ContainerRegistry --wait
+
+az group create \
+  --name "$AZURE_RESOURCE_GROUP" \
+  --location "$AZURE_LOCATION" \
+  --output table
+
+az acr create \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --name "$AZURE_ACR_NAME" \
+  --sku "$AZURE_ACR_SKU" \
+  --output table
+
+az acr update --name "$AZURE_ACR_NAME" --admin-enabled true --output none
+
+IMAGE="$AZURE_ACR_NAME.azurecr.io/$AZURE_IMAGE_NAME:$AZURE_IMAGE_TAG"
+az acr build \
+  --registry "$AZURE_ACR_NAME" \
+  --image "$AZURE_IMAGE_NAME:$AZURE_IMAGE_TAG" \
+  --file demo/Dockerfile.azure-gpu \
+  .
+
+if ! az containerapp env show \
+  --name "$AZURE_CONTAINERAPP_ENV" \
+  --resource-group "$AZURE_RESOURCE_GROUP" >/dev/null 2>&1; then
+  az containerapp env create \
+    --name "$AZURE_CONTAINERAPP_ENV" \
+    --resource-group "$AZURE_RESOURCE_GROUP" \
+    --location "$AZURE_LOCATION" \
+    --output table
+fi
+
+if ! az containerapp env workload-profile show \
+  --name "$AZURE_CONTAINERAPP_ENV" \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --workload-profile-name "$AZURE_WORKLOAD_PROFILE_NAME" >/dev/null 2>&1; then
+  az containerapp env workload-profile add \
+    --name "$AZURE_CONTAINERAPP_ENV" \
+    --resource-group "$AZURE_RESOURCE_GROUP" \
+    --workload-profile-name "$AZURE_WORKLOAD_PROFILE_NAME" \
+    --workload-profile-type Consumption-GPU-NC8as-T4
+fi
+
+ACR_USERNAME="$(az acr credential show --name "$AZURE_ACR_NAME" --query username -o tsv)"
+ACR_PASSWORD="$(az acr credential show --name "$AZURE_ACR_NAME" --query 'passwords[0].value' -o tsv)"
+
+ENV_VARS=(
+  "STEALTHRL_DEMO_INFERENCE_BACKEND=hf"
+  "STEALTHRL_DEMO_HF_DTYPE=float16"
+  "STEALTHRL_DEMO_HF_DEVICE_MAP=auto"
+  "STEALTHRL_DEMO_REQUEST_TIMEOUT_S=240"
+  "STEALTHRL_DEMO_PUBLIC_DAILY_LIMIT=$STEALTHRL_DEMO_PUBLIC_DAILY_LIMIT"
+  "STEALTHRL_DEMO_PUBLIC_QUOTA_SCOPE=$STEALTHRL_DEMO_PUBLIC_QUOTA_SCOPE"
+  "STEALTHRL_DEMO_MAX_CHARS=$STEALTHRL_DEMO_MAX_CHARS"
+  "STEALTHRL_DEMO_CORS_ORIGINS=$STEALTHRL_DEMO_CORS_ORIGINS"
+)
+
+if [[ -n "$STEALTHRL_DEMO_API_KEYS" ]]; then
+  ENV_VARS+=("STEALTHRL_DEMO_API_KEYS=$STEALTHRL_DEMO_API_KEYS")
+fi
+
+if az containerapp show \
+  --name "$AZURE_CONTAINERAPP_NAME" \
+  --resource-group "$AZURE_RESOURCE_GROUP" >/dev/null 2>&1; then
+  az containerapp update \
+    --name "$AZURE_CONTAINERAPP_NAME" \
+    --resource-group "$AZURE_RESOURCE_GROUP" \
+    --image "$IMAGE" \
+    --set-env-vars "${ENV_VARS[@]}" \
+    --min-replicas 0 \
+    --max-replicas 1 \
+    --output table
+else
+  az containerapp create \
+    --name "$AZURE_CONTAINERAPP_NAME" \
+    --resource-group "$AZURE_RESOURCE_GROUP" \
+    --environment "$AZURE_CONTAINERAPP_ENV" \
+    --image "$IMAGE" \
+    --registry-server "$AZURE_ACR_NAME.azurecr.io" \
+    --registry-username "$ACR_USERNAME" \
+    --registry-password "$ACR_PASSWORD" \
+    --target-port 8080 \
+    --ingress external \
+    --cpu 8.0 \
+    --memory 56.0Gi \
+    --workload-profile-name "$AZURE_WORKLOAD_PROFILE_NAME" \
+    --min-replicas 0 \
+    --max-replicas 1 \
+    --env-vars "${ENV_VARS[@]}" \
+    --output table
+fi
+
+FQDN="$(az containerapp show \
+  --name "$AZURE_CONTAINERAPP_NAME" \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --query properties.configuration.ingress.fqdn \
+  -o tsv)"
+
+echo "API URL: https://$FQDN"
+echo "Use this as --api-base-url for deploy_static_swa.sh."

--- a/deploy/azure/deploy_aca_gpu.sh
+++ b/deploy/azure/deploy_aca_gpu.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export PATH="$PWD/.venv-azure/bin:$PWD/.azure-tools/node_modules/.bin:$PATH"
+
 if ! command -v az >/dev/null 2>&1; then
   cat >&2 <<'EOF'
 Azure CLI is required but was not found.
-Install it, then run:
+Install it, or run from the repo root after installing local tooling, then run:
   az login --use-device-code
   az account set --subscription <SUBSCRIPTION_ID_OR_NAME>
 EOF

--- a/deploy/azure/deploy_aca_gpu.sh
+++ b/deploy/azure/deploy_aca_gpu.sh
@@ -15,6 +15,26 @@ fi
 
 az account show >/dev/null
 
+ensure_provider() {
+  local namespace="$1"
+  local state
+  state="$(az provider show --namespace "$namespace" --query registrationState -o tsv 2>/dev/null || true)"
+  if [[ "$state" != "Registered" ]]; then
+    az provider register --namespace "$namespace" --output none
+  fi
+
+  for _ in {1..60}; do
+    state="$(az provider show --namespace "$namespace" --query registrationState -o tsv 2>/dev/null || true)"
+    if [[ "$state" == "Registered" ]]; then
+      return 0
+    fi
+    sleep 10
+  done
+
+  echo "Timed out waiting for provider $namespace to register; last state: ${state:-unknown}" >&2
+  return 1
+}
+
 AZURE_RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:-stealthrl-demo-rg}"
 AZURE_LOCATION="${AZURE_LOCATION:-eastus}"
 AZURE_ACR_NAME="${AZURE_ACR_NAME:?Set AZURE_ACR_NAME to a globally unique lowercase registry name, e.g. stealthrldemo123}"
@@ -30,9 +50,9 @@ STEALTHRL_DEMO_PUBLIC_QUOTA_SCOPE="${STEALTHRL_DEMO_PUBLIC_QUOTA_SCOPE:-ip}"
 STEALTHRL_DEMO_MAX_CHARS="${STEALTHRL_DEMO_MAX_CHARS:-5000}"
 STEALTHRL_DEMO_API_KEYS="${STEALTHRL_DEMO_API_KEYS:-}"
 
-az provider register --namespace Microsoft.App --wait
-az provider register --namespace Microsoft.OperationalInsights --wait
-az provider register --namespace Microsoft.ContainerRegistry --wait
+ensure_provider Microsoft.App
+ensure_provider Microsoft.OperationalInsights
+ensure_provider Microsoft.ContainerRegistry
 
 az group create \
   --name "$AZURE_RESOURCE_GROUP" \

--- a/deploy/azure/deploy_aca_gpu.sh
+++ b/deploy/azure/deploy_aca_gpu.sh
@@ -44,7 +44,9 @@ AZURE_CONTAINERAPP_NAME="${AZURE_CONTAINERAPP_NAME:-stealthrl-demo-api}"
 AZURE_WORKLOAD_PROFILE_NAME="${AZURE_WORKLOAD_PROFILE_NAME:-gpu-t4}"
 AZURE_IMAGE_NAME="${AZURE_IMAGE_NAME:-stealthrl-demo-gpu}"
 AZURE_IMAGE_TAG="${AZURE_IMAGE_TAG:-$(git rev-parse --short HEAD 2>/dev/null || date +%Y%m%d%H%M%S)}"
-STEALTHRL_DEMO_CORS_ORIGINS="${STEALTHRL_DEMO_CORS_ORIGINS:-*}"
+AZURE_CONTAINERAPP_COOLDOWN_PERIOD="${AZURE_CONTAINERAPP_COOLDOWN_PERIOD:-120}"
+AZURE_CONTAINERAPP_POLLING_INTERVAL="${AZURE_CONTAINERAPP_POLLING_INTERVAL:-30}"
+STEALTHRL_DEMO_CORS_ORIGINS="${STEALTHRL_DEMO_CORS_ORIGINS:-https://stealthrl.pages.dev}"
 STEALTHRL_DEMO_PUBLIC_DAILY_LIMIT="${STEALTHRL_DEMO_PUBLIC_DAILY_LIMIT:-20}"
 STEALTHRL_DEMO_PUBLIC_QUOTA_SCOPE="${STEALTHRL_DEMO_PUBLIC_QUOTA_SCOPE:-ip}"
 STEALTHRL_DEMO_MAX_CHARS="${STEALTHRL_DEMO_MAX_CHARS:-5000}"
@@ -144,6 +146,19 @@ else
     --output table
 fi
 
+APP_ID="$(az containerapp show \
+  --name "$AZURE_CONTAINERAPP_NAME" \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --query id \
+  -o tsv)"
+
+az rest \
+  --method patch \
+  --url "https://management.azure.com${APP_ID}?api-version=2026-03-02-preview" \
+  --headers 'Content-Type=application/json' \
+  --body "{\"properties\":{\"template\":{\"scale\":{\"minReplicas\":0,\"maxReplicas\":1,\"cooldownPeriod\":${AZURE_CONTAINERAPP_COOLDOWN_PERIOD},\"pollingInterval\":${AZURE_CONTAINERAPP_POLLING_INTERVAL},\"rules\":null}}}}" \
+  --output none
+
 FQDN="$(az containerapp show \
   --name "$AZURE_CONTAINERAPP_NAME" \
   --resource-group "$AZURE_RESOURCE_GROUP" \
@@ -151,4 +166,4 @@ FQDN="$(az containerapp show \
   -o tsv)"
 
 echo "API URL: https://$FQDN"
-echo "Use this as --api-base-url for deploy_static_swa.sh."
+echo "Use this as STEALTHRL_API_BASE_URL for deploy/cloudflare/deploy_pages.sh."

--- a/deploy/azure/deploy_static_swa.sh
+++ b/deploy/azure/deploy_static_swa.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v az >/dev/null 2>&1; then
+  echo "Azure CLI is required. Install it and run az login first." >&2
+  exit 1
+fi
+
+if ! command -v swa >/dev/null 2>&1; then
+  echo "Azure Static Web Apps CLI is required. Install with: npm install -g @azure/static-web-apps-cli" >&2
+  exit 1
+fi
+
+az account show >/dev/null
+
+AZURE_RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:-stealthrl-demo-rg}"
+AZURE_STATIC_LOCATION="${AZURE_STATIC_LOCATION:-eastus2}"
+AZURE_STATIC_WEBAPP_NAME="${AZURE_STATIC_WEBAPP_NAME:-stealthrl-demo-web}"
+STEALTHRL_API_BASE_URL="${STEALTHRL_API_BASE_URL:?Set STEALTHRL_API_BASE_URL, e.g. https://<container-app-fqdn>}"
+STATIC_DIST="${STATIC_DIST:-deploy/azure/static_dist}"
+
+az provider register --namespace Microsoft.Web --wait
+
+az staticwebapp create \
+  --name "$AZURE_STATIC_WEBAPP_NAME" \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --location "$AZURE_STATIC_LOCATION" \
+  --sku Free \
+  --output table
+
+python deploy/azure/build_static_dist.py \
+  --api-base-url "$STEALTHRL_API_BASE_URL" \
+  --out "$STATIC_DIST"
+
+DEPLOYMENT_TOKEN="$(az staticwebapp secrets list \
+  --name "$AZURE_STATIC_WEBAPP_NAME" \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --query properties.apiKey \
+  -o tsv)"
+
+swa deploy "$STATIC_DIST" \
+  --deployment-token "$DEPLOYMENT_TOKEN" \
+  --env production
+
+DEFAULT_HOSTNAME="$(az staticwebapp show \
+  --name "$AZURE_STATIC_WEBAPP_NAME" \
+  --resource-group "$AZURE_RESOURCE_GROUP" \
+  --query defaultHostname \
+  -o tsv)"
+
+echo "Static site URL: https://$DEFAULT_HOSTNAME"
+echo "For stricter CORS, rerun deploy_aca_gpu.sh with:"
+echo "  export STEALTHRL_DEMO_CORS_ORIGINS=https://$DEFAULT_HOSTNAME"

--- a/deploy/azure/deploy_static_swa.sh
+++ b/deploy/azure/deploy_static_swa.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+export PATH="$PWD/.venv-azure/bin:$PWD/.azure-tools/node_modules/.bin:$PATH"
+
 if ! command -v az >/dev/null 2>&1; then
   echo "Azure CLI is required. Install it and run az login first." >&2
   exit 1

--- a/deploy/azure/deploy_static_swa.sh
+++ b/deploy/azure/deploy_static_swa.sh
@@ -15,13 +15,33 @@ fi
 
 az account show >/dev/null
 
+ensure_provider() {
+  local namespace="$1"
+  local state
+  state="$(az provider show --namespace "$namespace" --query registrationState -o tsv 2>/dev/null || true)"
+  if [[ "$state" != "Registered" ]]; then
+    az provider register --namespace "$namespace" --output none
+  fi
+
+  for _ in {1..60}; do
+    state="$(az provider show --namespace "$namespace" --query registrationState -o tsv 2>/dev/null || true)"
+    if [[ "$state" == "Registered" ]]; then
+      return 0
+    fi
+    sleep 10
+  done
+
+  echo "Timed out waiting for provider $namespace to register; last state: ${state:-unknown}" >&2
+  return 1
+}
+
 AZURE_RESOURCE_GROUP="${AZURE_RESOURCE_GROUP:-stealthrl-demo-rg}"
 AZURE_STATIC_LOCATION="${AZURE_STATIC_LOCATION:-eastus2}"
 AZURE_STATIC_WEBAPP_NAME="${AZURE_STATIC_WEBAPP_NAME:-stealthrl-demo-web}"
 STEALTHRL_API_BASE_URL="${STEALTHRL_API_BASE_URL:?Set STEALTHRL_API_BASE_URL, e.g. https://<container-app-fqdn>}"
 STATIC_DIST="${STATIC_DIST:-deploy/azure/static_dist}"
 
-az provider register --namespace Microsoft.Web --wait
+ensure_provider Microsoft.Web
 
 az staticwebapp create \
   --name "$AZURE_STATIC_WEBAPP_NAME" \

--- a/deploy/cloudflare/deploy_pages.sh
+++ b/deploy/cloudflare/deploy_pages.sh
@@ -21,22 +21,18 @@ python deploy/azure/build_static_dist.py \
   --api-base-url "$STEALTHRL_API_BASE_URL" \
   --out "$STATIC_DIST"
 
+mkdir -p "$STATIC_DIST/privacy"
+cp "$STATIC_DIST/privacy.html" "$STATIC_DIST/privacy/index.html"
+
 cat > "$STATIC_DIST/_redirects" <<'EOF'
-/privacy  /privacy.html  200
+/privacy  /privacy/  308
 EOF
 
-if [[ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
-  if ! create_output="$(wrangler pages project create "$CLOUDFLARE_PAGES_PROJECT" \
-    --production-branch "$CLOUDFLARE_PAGES_BRANCH" 2>&1)"; then
-    if ! grep -Eiq 'already exists|already.*project|project.*exists' <<<"$create_output"; then
-      printf '%s\n' "$create_output" >&2
-      exit 1
-    fi
-  fi
-else
-  if ! wrangler pages project list | awk 'NR > 1 {print $1}' | grep -Fxq "$CLOUDFLARE_PAGES_PROJECT"; then
-    wrangler pages project create "$CLOUDFLARE_PAGES_PROJECT" \
-      --production-branch "$CLOUDFLARE_PAGES_BRANCH"
+if ! create_output="$(wrangler pages project create "$CLOUDFLARE_PAGES_PROJECT" \
+  --production-branch "$CLOUDFLARE_PAGES_BRANCH" 2>&1)"; then
+  if ! grep -Eiq 'already exists|project with this name already exists|project.*exists' <<<"$create_output"; then
+    printf '%s\n' "$create_output" >&2
+    exit 1
   fi
 fi
 

--- a/deploy/cloudflare/deploy_pages.sh
+++ b/deploy/cloudflare/deploy_pages.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="$PWD/.cloudflare-tools/node_modules/.bin:$PATH"
+
+if ! command -v wrangler >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+Wrangler is required but was not found.
+Install it locally from the repo root with:
+  npm install --prefix .cloudflare-tools wrangler
+EOF
+  exit 1
+fi
+
+CLOUDFLARE_PAGES_PROJECT="${CLOUDFLARE_PAGES_PROJECT:-stealthrl}"
+CLOUDFLARE_PAGES_BRANCH="${CLOUDFLARE_PAGES_BRANCH:-$(git branch --show-current 2>/dev/null || echo demo-website)}"
+STEALTHRL_API_BASE_URL="${STEALTHRL_API_BASE_URL:?Set STEALTHRL_API_BASE_URL, e.g. https://<container-app-fqdn>}"
+STATIC_DIST="${STATIC_DIST:-deploy/cloudflare/static_dist}"
+
+python deploy/azure/build_static_dist.py \
+  --api-base-url "$STEALTHRL_API_BASE_URL" \
+  --out "$STATIC_DIST"
+
+cat > "$STATIC_DIST/_redirects" <<'EOF'
+/privacy  /privacy.html  200
+EOF
+
+if [[ -n "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
+  if ! create_output="$(wrangler pages project create "$CLOUDFLARE_PAGES_PROJECT" \
+    --production-branch "$CLOUDFLARE_PAGES_BRANCH" 2>&1)"; then
+    if ! grep -Eiq 'already exists|already.*project|project.*exists' <<<"$create_output"; then
+      printf '%s\n' "$create_output" >&2
+      exit 1
+    fi
+  fi
+else
+  if ! wrangler pages project list | awk 'NR > 1 {print $1}' | grep -Fxq "$CLOUDFLARE_PAGES_PROJECT"; then
+    wrangler pages project create "$CLOUDFLARE_PAGES_PROJECT" \
+      --production-branch "$CLOUDFLARE_PAGES_BRANCH"
+  fi
+fi
+
+wrangler pages deploy "$STATIC_DIST" \
+  --project-name "$CLOUDFLARE_PAGES_PROJECT" \
+  --branch "$CLOUDFLARE_PAGES_BRANCH" \
+  --commit-dirty=true
+
+echo "Cloudflare Pages URL: https://$CLOUDFLARE_PAGES_PROJECT.pages.dev"

--- a/tests/test_demo_api.py
+++ b/tests/test_demo_api.py
@@ -1,0 +1,74 @@
+from pathlib import Path
+
+from fastapi.testclient import TestClient
+
+from demo.stealthrl_demo.app import create_app
+from demo.stealthrl_demo.config import ApiKeyConfig, DemoSettings
+from demo.stealthrl_demo.rate_limit import QuotaStore
+
+
+def _client(tmp_path: Path, public_limit: int = 2) -> TestClient:
+    settings = DemoSettings(
+        public_daily_limit=public_limit,
+        public_quota_scope="ip",
+        db_path=tmp_path / "usage.sqlite3",
+        api_keys=(ApiKeyConfig(key="stealth-test-key", label="test", daily_limit=10),),
+        inference_backend="mock",
+        max_chars=1000,
+    )
+    quota_store = QuotaStore(
+        db_path=settings.db_path,
+        api_keys=settings.api_keys,
+        public_daily_limit=settings.public_daily_limit,
+        public_quota_scope=settings.public_quota_scope,
+    )
+    return TestClient(create_app(settings=settings, quota_store=quota_store))
+
+
+def test_public_quota_is_enforced(tmp_path):
+    client = _client(tmp_path, public_limit=1)
+    payload = {
+        "text": "AI text detectors can fail when adversarial paraphrasing changes surface form while preserving meaning."
+    }
+    first = client.post("/api/paraphrase", json=payload)
+    assert first.status_code == 200
+    assert first.json()["quota"]["remaining"] == 0
+
+    second = client.post("/api/paraphrase", json=payload)
+    assert second.status_code == 429
+
+
+def test_index_serves_static_demo(tmp_path):
+    client = _client(tmp_path)
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "StealthRL Demo" in response.text
+
+
+def test_api_key_bypasses_public_quota(tmp_path):
+    client = _client(tmp_path, public_limit=0)
+    payload = {
+        "text": "AI text detectors can fail when adversarial paraphrasing changes surface form while preserving meaning."
+    }
+    response = client.post(
+        "/api/paraphrase",
+        json=payload,
+        headers={"Authorization": "Bearer stealth-test-key"},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["quota"]["authenticated"] is True
+    assert body["output_text"]
+
+
+def test_invalid_api_key_is_rejected(tmp_path):
+    client = _client(tmp_path)
+    payload = {
+        "text": "AI text detectors can fail when adversarial paraphrasing changes surface form while preserving meaning."
+    }
+    response = client.post(
+        "/api/paraphrase",
+        json=payload,
+        headers={"X-StealthRL-API-Key": "not-a-real-key"},
+    )
+    assert response.status_code == 401

--- a/tests/test_demo_api.py
+++ b/tests/test_demo_api.py
@@ -45,6 +45,14 @@ def test_index_serves_static_demo(tmp_path):
     assert "StealthRL Demo" in response.text
 
 
+def test_privacy_page_serves_static_document(tmp_path):
+    client = _client(tmp_path)
+    response = client.get("/privacy")
+    assert response.status_code == 200
+    assert "Privacy information" in response.text
+    assert "StealthRL Demo" in response.text
+
+
 def test_api_key_bypasses_public_quota(tmp_path):
     client = _client(tmp_path, public_limit=0)
     payload = {


### PR DESCRIPTION
## Summary

Adds the StealthRL public demo stack: a FastAPI backend, static frontend, API-key/public-quota access controls, feedback capture, detector handoff links, privacy page, and deployment scripts for Cloudflare Pages plus Azure Container Apps GPU.

## Deployment impact

- Frontend is intended to run on Cloudflare Pages at `https://stealthrl.pages.dev`.
- Backend is configured for Azure Container Apps GPU with `minReplicas=0`, `maxReplicas=1`, and a `120s` cooldown to reduce idle GPU spend.
- The Azure deploy script now defaults CORS to the Cloudflare Pages origin and patches the cooldown using the preview Container Apps API.

## Validation

- Live Azure backend revision `stealthrl-demo-api--0000007` was verified healthy, serving traffic, and scaling to zero after the idle window.
- Ran `python -m pytest tests/test_demo_api.py`: `5 passed`.

## Notes

The PR is draft because deployment secrets and production quota/API-key policy should get one human pass before merge.